### PR TITLE
Only check for -n flag as first argument. Fix extra white space.

### DIFF
--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -10,13 +10,19 @@ use coreutils::extra::OptionalExt;
 fn main() {
     let mut stdout = stdout();
 
+    let mut args = env::args();
     let mut newline = true;
-    for arg in env::args().skip(1) {
+
+    if let Some(arg) = args.nth(1) {
         if arg == "-n" {
             newline = false;
+            if let Some(arg) = args.nth(0) {write!(stdout, "{}", arg).try();}
         } else {
-            write!(stdout, "{} ", arg).try();
+            write!(stdout, "{}", arg).try();
         }
+    }
+    for arg in args {
+        write!(stdout, " {}", arg).try();
     }
     if newline {
         write!(stdout, "\n").try();


### PR DESCRIPTION
Simple change to only accept the -n flag if it is the first argument, which as far as I could see I how most echo implementations does it including `tcsh`. Also some changes to how it is written out, to remove the trailing white space after the last argument.