### PR TITLE
Fix Compile Errors

### DIFF
--- a/src/bin/wc.rs
+++ b/src/bin/wc.rs
@@ -1,4 +1,6 @@
 #![deny(warnings)]
+#![feature(augmented_assignments)]
+#![feature(op_assign_traits)]
 
 extern crate coreutils;
 


### PR DESCRIPTION
Coreutils cannot currently be compiled due to using unstable features without enabling their usage.