### PR TITLE
Proposal: Improved Implementation of Sleep Command

### DIFF
--- a/src/bin/sleep.rs
+++ b/src/bin/sleep.rs
@@ -32,8 +32,8 @@ AUTHOR
     Written by Michael Murphy.
 "#;
 
-const MISSING_OPERAND: &'static str = "missing operand";
-const HELP_INFO:       &'static str = "Try 'sleep --help' for more information.";
+const MISSING_OPERAND: &'static str = "missing operand\n";
+const HELP_INFO:       &'static str = "Try 'sleep --help' for more information.\n";
 
 fn main() {
     let stdout     = io::stdout();

--- a/src/bin/sleep.rs
+++ b/src/bin/sleep.rs
@@ -10,29 +10,31 @@ use std::time::Duration;
 
 use coreutils::extra::{OptionalExt};
 
-static MAN_PAGE: &'static str = r#"NAME
+const MAN_PAGE: &'static str = r#"NAME
     sleep - delay for a specified amount of time
 
 SYNOPSIS
-    sleep NUMBER[SUFFIX]...
-    sleep OPTION
+    sleep [-h | --help] NUMBER[SUFFIX]...
 
 DESCRIPTION
     Pause the shell for NUMBER seconds. An optional SUFFIX may be applied, such as 's' for seconds (default), 'm' for minutes, 'h' for hours or 'd' for day. Given multiple arguments, it will pause for the amount of time specified by the sum of their values. This implementation supports floating point numbers as input.
 
-    Example: sleep 60; sleep 1m; sleep 30s 30s;
-             sleep 0.5; sleep 0.5s; sleep 0.25s 0.25s
+EXAMPLE
+    The following are three possible arguments with the same effect:
+
+    sleep {90, 1.5m, 1m 30s}
 
 OPTIONS
-    -h, --help
+    -h
+    --help
         display this help and exit
 
 AUTHOR
-    Written by Jeremy Soller and Michael Murphy.
+    Written by Michael Murphy.
 "#;
 
-static MISSING_OPERAND: &'static str       = "sleep: missing operand";
-static HELP_INFO: &'static str             = "Try 'sleep --help' for more information.";
+const MISSING_OPERAND: &'static str = "missing operand";
+const HELP_INFO:       &'static str = "Try 'sleep --help' for more information.";
 
 fn main() {
     let stdout     = io::stdout();
@@ -46,7 +48,6 @@ fn main() {
                 stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
             },
             _ => {
-                // TODO: (not supported in Redox due to missing _mulodi4) thread::sleep(Duration::new(arg.parse().try(), 0))
                 thread::sleep(Duration::from_millis(argument_to_ms(&arg)));
                 for argument in args {
                     thread::sleep(Duration::from_millis(argument_to_ms(&argument)));
@@ -54,7 +55,7 @@ fn main() {
             }
         }
     } else {
-        stdout.write(MISSING_OPERAND.as_bytes()).try(&mut stderr);
+        stderr.write(MISSING_OPERAND.as_bytes()).try(&mut stderr);
         stdout.write(HELP_INFO.as_bytes()).try(&mut stderr);
     }
 }
@@ -65,6 +66,8 @@ fn argument_to_ms(argument: &str) -> u64 {
     if let Ok(number) = argument.parse::<f64>() {
         return (number * 1000f64) as u64;
     }
+
+    let mut stderr = io::stderr();
 
     // Split the argument into two strings at the last character. The first string should be the
     // number while the second string should be the duration unit:
@@ -77,12 +80,18 @@ fn argument_to_ms(argument: &str) -> u64 {
             "h" => (number * 3600000f64) as u64,
             "d" => (number * 86400000f64) as u64,
             _   => {
-                println!("sleep: invalid time interval '{}'", argument);
+                let mut output = String::from("invalid time interval '");
+                output.push_str(argument);
+                output.push_str("\'\n");
+                stderr.write(output.as_bytes()).try(&mut stderr);
                 std::process::exit(1);
             }
         }
     } else {
-        println!("sleep: invalid time interval '{}'", argument);
+        let mut output = String::from("invalid time interval '");
+        output.push_str(argument);
+        output.push_str("\'\n");
+        stderr.write(output.as_bytes()).try(&mut stderr);
         std::process::exit(1);
     }
 }

--- a/src/bin/sleep.rs
+++ b/src/bin/sleep.rs
@@ -3,19 +3,86 @@
 extern crate coreutils;
 
 use std::env;
+use std::io::{self, Write};
 use std::thread;
-use std::io;
+use std::time::Duration;
 
-use coreutils::extra::{OptionalExt, fail};
 
-#[allow(deprecated)]
+use coreutils::extra::{OptionalExt};
+
+static MAN_PAGE: &'static str = r#"NAME
+    sleep - delay for a specified amount of time
+
+SYNOPSIS
+    sleep NUMBER[SUFFIX]...
+    sleep OPTION
+
+DESCRIPTION
+    Pause the shell for NUMBER seconds. An optional SUFFIX may be applied, such as 's' for seconds (default), 'm' for minutes, 'h' for hours or 'd' for day. Given multiple arguments, it will pause for the amount of time specified by the sum of their values. This implementation supports floating point numbers as input.
+
+    Example: sleep 60; sleep 1m; sleep 30s 30s;
+             sleep 0.5; sleep 0.5s; sleep 0.25s 0.25s
+
+OPTIONS
+    -h, --help
+        display this help and exit
+
+AUTHOR
+    Written by Jeremy Soller and Michael Murphy.
+"#;
+
+static MISSING_OPERAND: &'static str       = "sleep: missing operand";
+static HELP_INFO: &'static str             = "Try 'sleep --help' for more information.";
+
 fn main() {
+    let stdout     = io::stdout();
+    let mut stdout = stdout.lock();
     let mut stderr = io::stderr();
+    let mut args   = env::args().skip(1);
 
-    if let Some(arg) = env::args().nth(1) {
-        // TODO: (not supported in Redox due to missing _mulodi4) thread::sleep(Duration::new(arg.parse().try(), 0))
-        thread::sleep_ms(arg.parse::<u32>().try(&mut stderr) * 1000);
+    if let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            },
+            _ => {
+                // TODO: (not supported in Redox due to missing _mulodi4) thread::sleep(Duration::new(arg.parse().try(), 0))
+                thread::sleep(Duration::from_millis(argument_to_ms(&arg)));
+                for argument in args {
+                    thread::sleep(Duration::from_millis(argument_to_ms(&argument)));
+                }
+            }
+        }
     } else {
-        fail("missing argument.", &mut stderr);
+        stdout.write(MISSING_OPERAND.as_bytes()).try(&mut stderr);
+        stdout.write(HELP_INFO.as_bytes()).try(&mut stderr);
+    }
+}
+
+/// Check if the argument uses a time suffix and convert the time accordingly.
+fn argument_to_ms(argument: &str) -> u64 {
+    // If the argument is a number, the duration is in seconds, so multiply it by 1000.
+    if let Ok(number) = argument.parse::<f64>() {
+        return (number * 1000f64) as u64;
+    }
+
+    // Split the argument into two strings at the last character. The first string should be the
+    // number while the second string should be the duration unit:
+    // s = seconds; m = minutes; h = hours; d = days
+    let (prefix, suffix) = argument.split_at(argument.len()-1);
+    if let Ok(number) = prefix.parse::<f64>() {
+        match suffix {
+            "s" => (number * 1000f64) as u64,
+            "m" => (number * 60000f64) as u64,
+            "h" => (number * 3600000f64) as u64,
+            "d" => (number * 86400000f64) as u64,
+            _   => {
+                println!("sleep: invalid time interval '{}'", argument);
+                std::process::exit(1);
+            }
+        }
+    } else {
+        println!("sleep: invalid time interval '{}'", argument);
+        std::process::exit(1);
     }
 }

--- a/src/bin/sleep.rs
+++ b/src/bin/sleep.rs
@@ -7,7 +7,6 @@ use std::io::{self, Write};
 use std::thread;
 use std::time::Duration;
 
-
 use coreutils::extra::{OptionalExt};
 
 const MAN_PAGE: &'static str = r#"NAME
@@ -80,18 +79,18 @@ fn argument_to_ms(argument: &str) -> u64 {
             "h" => (number * 3600000f64) as u64,
             "d" => (number * 86400000f64) as u64,
             _   => {
-                let mut output = String::from("invalid time interval '");
-                output.push_str(argument);
-                output.push_str("\'\n");
-                stderr.write(output.as_bytes()).try(&mut stderr);
+                stderr.write(b"invalid time interval '").try(&mut stderr);
+                stderr.write(argument.as_bytes()).try(&mut stderr);
+                stderr.write(b"\'\n").try(&mut stderr);
+                stderr.flush().try(&mut stderr);
                 std::process::exit(1);
             }
         }
     } else {
-        let mut output = String::from("invalid time interval '");
-        output.push_str(argument);
-        output.push_str("\'\n");
-        stderr.write(output.as_bytes()).try(&mut stderr);
+        stderr.write(b"invalid time interval '").try(&mut stderr);
+        stderr.write(argument.as_bytes()).try(&mut stderr);
+        stderr.write(b"\'\n").try(&mut stderr);
+        stderr.flush().try(&mut stderr);
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
With this patch, the sleep command will be able to process floating point numbers as input so that it will be possible to sleep for shorter time periods, such as 0.5 seconds. It will also be able to accept input with a human-readable suffix indicating the duration of time to sleep (s for seconds, m for minutes, h for hours and d for days). Finally, it will also be able to accept multiple input arguments, allowing sleep to sleep for the combined amount of time specified (will make more sense for why when given the following example). In addition, I've also replaced the deprecated code with the current standard.

### **Example:**
- `sleep 60` is equivalent to `sleep 1m`
- `sleep 90` is equivalent to `sleep 1.5m` is equivalent to `sleep 1m 30s`