### PR TITLE
Clippy Fixes & Basename/Cat Fixes

### DIFF
--- a/src/bin/basename.rs
+++ b/src/bin/basename.rs
@@ -3,6 +3,7 @@ extern crate extra;
 
 use std::io::{self, Write};
 use extra::option::OptionalExt;
+use std::process;
 
 const MAN_PAGE: &'static str = /* @MANSTART{basename} */ r#"
 NAME
@@ -74,14 +75,14 @@ fn main() {
                             stdout.write_all(HELP_INFO.as_bytes()).try(&mut stderr);
                             stderr.flush().try(&mut stderr);
                             stdout.flush().try(&mut stderr);
-                            std::process::exit(1);
+                            process::exit(1);
                         }
                     },
                     "-z" | "--zero"     => zero = true,
                     "-h" | "--help"     => {
                         stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
                         stdout.flush().try(&mut stderr);
-                        std::process::exit(1);
+                        process::exit(1);
                     },
                     _ => {
                         stderr.write_all("invalid option -- ‘".as_bytes()).try(&mut stderr);
@@ -90,7 +91,7 @@ fn main() {
                         stdout.write_all(HELP_INFO.as_bytes()).try(&mut stderr);
                         stderr.flush().try(&mut stderr);
                         stdout.flush().try(&mut stderr);
-                        std::process::exit(1);
+                        process::exit(1);
                     }
                 }
             } else {
@@ -100,7 +101,7 @@ fn main() {
         } else {
             stdout.write_all(MISSING_OPERAND.as_bytes()).try(&mut stderr);
             stdout.write_all(HELP_INFO.as_bytes()).try(&mut stderr);
-            std::process::exit(0);
+            process::exit(0);
         }
     }
 
@@ -118,7 +119,7 @@ fn main() {
                     stdout.write_all(HELP_INFO.as_bytes()).try(&mut stderr);
                     stderr.flush().try(&mut stderr);
                     stdout.flush().try(&mut stderr);
-                    std::process::exit(1);
+                    process::exit(1);
                 }
 
                 // Otherwise, set the suffix variable to the argument we found.
@@ -159,7 +160,7 @@ fn basename(zero: bool, input: &str, suffix: &str, stdout: &mut io::StdoutLock, 
                 stderr.write_all(path.as_bytes()).try(stderr);
                 stderr.write_all("’\n".as_bytes()).try(stderr);
                 stderr.flush().try(stderr);
-                std::process::exit(1);
+                process::exit(1);
             }
 
         },
@@ -168,7 +169,7 @@ fn basename(zero: bool, input: &str, suffix: &str, stdout: &mut io::StdoutLock, 
             stderr.write_all(path.as_bytes()).try(stderr);
             stderr.write_all("’\n".as_bytes()).try(stderr);
             stderr.flush().try(stderr);
-            std::process::exit(1);
+            process::exit(1);
         }
     };
 

--- a/src/bin/basename.rs
+++ b/src/bin/basename.rs
@@ -100,7 +100,7 @@ fn main() {
         } else {
             stdout.write_all(MISSING_OPERAND.as_bytes()).try(&mut stderr);
             stdout.write_all(HELP_INFO.as_bytes()).try(&mut stderr);
-            return;
+            std::process::exit(0);
         }
     }
 
@@ -141,11 +141,11 @@ fn main() {
 /// suffix, the suffix will be removed.
 fn basename(zero: bool, input: &str, suffix: &str, stdout: &mut io::StdoutLock, stderr: &mut io::Stderr) {
     // If the suffix variable is set, remove the suffix from the path string.
-    let path = if !suffix.is_empty() {
+    let path = if suffix.is_empty() {
+        input
+    } else {
         let (prefix, input_suffix) = input.split_at(input.len() - suffix.len());
         if input_suffix == suffix { prefix } else { input }
-    } else {
-        input
     };
 
     // Only print the basename of the the path.

--- a/src/bin/cat.rs
+++ b/src/bin/cat.rs
@@ -144,7 +144,7 @@ impl Program {
         let stdin = io::stdin();
         let mut stdin = stdin.lock();
 
-        if self.paths.len() == 0 {
+        if self.paths.is_empty() {
             io::copy(&mut stdin, stdout).try(stderr);
         } else {
             let mut line_count = 1;
@@ -229,15 +229,13 @@ impl Program {
                             },
                         }
                     }
+                } else if path == "-" {
+                    io::copy(&mut stdin, stdout).try(stderr);
                 } else {
-                    if path == "-" {
-                        io::copy(&mut stdin, stdout).try(stderr);
-                    } else {
-                        let file = fs::File::open(&path);
-                        let mut file = file.try(stderr);
+                    let file = fs::File::open(&path);
+                    let mut file = file.try(stderr);
 
-                        io::copy(&mut file, stdout).try(stderr);
-                    }
+                    io::copy(&mut file, stdout).try(stderr);
                 }
             }
         }

--- a/src/bin/cat.rs
+++ b/src/bin/cat.rs
@@ -143,13 +143,15 @@ impl Program {
     fn and_execute(&self, stdout: &mut StdoutLock, stderr: &mut Stderr) -> i32 {
         let stdin = io::stdin();
         let stdin = &mut stdin.lock();
+        let line_count = &mut 0usize;
+        let flags_enabled = self.number || self.number_nonblank || self.show_ends || self.show_tabs ||
+                            self.squeeze_blank || self.show_nonprinting;
 
-        if self.paths.is_empty() {
+        if self.paths.is_empty() && flags_enabled {
+            self.cat_stdin(line_count, stdin, stdout, stderr);
+        } else if self.paths.is_empty() {
             io::copy(stdin, stdout).try(stderr);
         } else {
-            let flags_enabled = self.number || self.number_nonblank || self.show_ends || self.show_tabs ||
-                                self.squeeze_blank || self.show_nonprinting;
-            let line_count = &mut 0usize;
             for path in &self.paths {
                 if flags_enabled && path == "-" {
                     self.cat_stdin(line_count, stdin, stdout, stderr);

--- a/src/bin/cut.rs
+++ b/src/bin/cut.rs
@@ -1,6 +1,7 @@
 extern crate extra;
 
 use std::env;
+use std::fmt;
 use std::fs;
 use std::io::{self, BufRead, Read, Write};
 use std::slice;
@@ -130,7 +131,7 @@ impl FromStr for Selection {
                 // Range: M-N
                 (Some(&Ok(begin)), Some(&Ok(end))) => fill(&mut selected, begin - 1, end),
 
-                _ => return Err(ParseSelectionError{ _priv: () }),
+                _ => return Err(ParseSelectionError{ part: String::from(part) }),
             }
         }
         Ok(Selection {
@@ -140,7 +141,14 @@ impl FromStr for Selection {
     }
 }
 
-struct ParseSelectionError { _priv: () }
+struct ParseSelectionError { part: String }
+
+/// If an unwrap fails, print this message.
+impl fmt::Debug for ParseSelectionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "illegal part: {}", self.part)
+    }
+}
 
 /// Iterator that simultaneoulsy iters over a value and a boolean iterator,
 /// yielding a value from the first when the second is True.
@@ -427,6 +435,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use std::io;
+    use std::str::FromStr;
 
     use super::{cut_characters, cut_bytes, cut_fields, Selection};
 
@@ -510,10 +519,10 @@ mod tests {
 
     #[test]
     fn parse_err() {
-        assert!(Selection::from_str("").is_none());
-        assert!(Selection::from_str("X").is_none());
-        assert!(Selection::from_str("1;5").is_none());
-        assert!(Selection::from_str("1,3,5-X ").is_none());
+        assert!(Selection::from_str("").is_err());
+        assert!(Selection::from_str("X").is_err());
+        assert!(Selection::from_str("1;5").is_err());
+        assert!(Selection::from_str("1,3,5-X ").is_err());
     }
 
 

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -159,27 +159,27 @@ fn evaluate_expression(first: &str, operator: Option<&String>, second_argument: 
                         "!=" => evaluate_bool(first != second),
                         "-eq" => {
                             let (left, right) = parse_integers(first, second, stderr);
-                            return evaluate_bool(left == right);
+                            evaluate_bool(left == right)
                         },
                         "-ge" => {
                             let (left, right) = parse_integers(first, second, stderr);
-                            return evaluate_bool(left >= right);
+                            evaluate_bool(left >= right)
                         },
                         "-gt" => {
                             let (left, right) = parse_integers(first, second, stderr);
-                            return evaluate_bool(left > right);
+                            evaluate_bool(left > right)
                         },
                         "-le" => {
                             let (left, right) = parse_integers(first, second, stderr);
-                            return evaluate_bool(left <= right);
+                            evaluate_bool(left <= right)
                         },
                         "-lt" => {
                             let (left, right) = parse_integers(first, second, stderr);
-                            return evaluate_bool(left < right);
+                            evaluate_bool(left < right)
                         },
                         "-ne" => {
                             let (left, right) = parse_integers(first, second, stderr);
-                            return evaluate_bool(left != right);
+                            evaluate_bool(left != right)
                         },
                         "-ef" => files_have_same_device_and_inode_numbers(first, second),
                         "-nt" => file_is_newer_than(first, second),
@@ -189,14 +189,14 @@ fn evaluate_expression(first: &str, operator: Option<&String>, second_argument: 
                             stderr.write_all(op.as_bytes()).try(stderr);
                             stderr.write_all(&[b'\n']).try(stderr);
                             stderr.flush().try(stderr);
-                            return FAILED
+                            FAILED
                         }
                     }
                 },
                 None => {
                     stderr.write_all(b"parse error: condition expected\n").try(stderr);
                     stderr.flush().try(stderr);
-                    return FAILED
+                    FAILED
                 }
             }
         },
@@ -245,7 +245,7 @@ fn file_is_newer_than(first: &str, second: &str) -> i32 {
 fn get_modified_file_time(filename: &str) -> Option<std::time::SystemTime> {
     match fs::metadata(filename) {
         Ok(file) => match file.modified() {
-            Ok(time) => return Some(time),
+            Ok(time) => Some(time),
             Err(_)   => None
         },
         Err(_) => None
@@ -280,9 +280,8 @@ fn match_flag_argument(character: Option<char>, arguments: Option<&String>) -> i
             'f' => file_is_regular(arguments),
             //'g' => file_is_set_group_id(arguments),
             //'G' => file_is_owned_by_effective_group_id(arguments),
-            'h' => file_is_symlink(arguments),
+            'h' | 'L' => file_is_symlink(arguments),
             //'k' => file_has_sticky_bit(arguments),
-            'L' => file_is_symlink(arguments),
             //'O' => file_is_owned_by_effective_user_id(arguments),
             //'p' => file_is_named_pipe(arguments),
             'r' => file_has_read_permission(arguments),


### PR DESCRIPTION
A simple assortment of fixes found by [clippy](https://github.com/Manishearth/rust-clippy). In addition to these fixes, there is also a fix for basename , cat and cut. For basename, std::process::exit() has a minor cosmetic change to rename it to process::exit(). For cat, the "-" path now works as an alias for stdin, and stdin now may be used with flag arguments. Finally, the tests for cut have been fixed.