### PR TITLE
Implement man page for mkdir, print it when executing mkdir --help.

### DIFF
--- a/src/bin/mkdir.rs
+++ b/src/bin/mkdir.rs
@@ -4,15 +4,38 @@ extern crate extra;
 
 use std::env;
 use std::fs;
-use std::io;
+use std::io::{stdout, stderr, Write};
 use extra::io::fail;
 use extra::option::OptionalExt;
 
+const MAN_PAGE: &'static str = /* @MANSTART{mkdir} */ r#"
+NAME
+    mkdir - make directories
+
+SYNOPSIS
+    mkdir DIRECTORIES...
+
+DESCRIPTION
+    The mkdir utility creates the directories named as operands.
+"#; /* @MANEND */
+
 fn main() {
-    let mut stderr = io::stderr();
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
 
     if env::args().count() < 2 {
-        fail("no arguments.", &mut stderr);
+        fail("No arguments. Use --help to see the usage.", &mut stderr);
+    }
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().last() {
+            if arg == "--help" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
     }
 
     for ref path in env::args().skip(1) {

--- a/src/bin/mkdir.rs
+++ b/src/bin/mkdir.rs
@@ -19,7 +19,7 @@ DESCRIPTION
     The mkdir utility creates the directories named as operands.
 
 OPTIONS
-    --help
+    --help, -h
         print this message
 "#; /* @MANEND */
 
@@ -34,7 +34,7 @@ fn main() {
 
     if env::args().count() == 2 {
         if let Some(arg) = env::args().nth(1) {
-            if arg == "--help" {
+            if arg == "--help" || arg == "-h" {
                 stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
                 stdout.flush().try(&mut stderr);
                 return;

--- a/src/bin/mkdir.rs
+++ b/src/bin/mkdir.rs
@@ -17,6 +17,10 @@ SYNOPSIS
 
 DESCRIPTION
     The mkdir utility creates the directories named as operands.
+
+OPTIONS
+    --help
+        print this message
 "#; /* @MANEND */
 
 fn main() {
@@ -29,7 +33,7 @@ fn main() {
     }
 
     if env::args().count() == 2 {
-        if let Some(arg) = env::args().last() {
+        if let Some(arg) = env::args().nth(1) {
             if arg == "--help" {
                 stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
                 stdout.flush().try(&mut stderr);


### PR DESCRIPTION
Hey,

My first attempt to contribute to this project! Saw the issue #19, thought it's a good starting point.

Didn't notice a consistent pattern for printing man pages (e.g. `test` prints with --help, `du` is not printing it but has `#![deny(warnings)]` comment out). Not sure if I missed one? So decided that --help option seems reasonable. Totally happy to change it if I missed some convention!

The build is passing here https://travis-ci.org/GedRap/coreutils/builds/130974461 .

Thanks.