### PR TITLE
Add manual pages to the tools that were missing it.

### DIFF
--- a/src/bin/cp.rs
+++ b/src/bin/cp.rs
@@ -4,17 +4,46 @@ extern crate extra;
 
 use std::env;
 use std::fs;
-use std::io::{self, Seek, SeekFrom, stderr};
+use std::io::{self, Seek, SeekFrom, stderr, stdout, Write};
 use extra::io::fail;
 use extra::option::OptionalExt;
 
+const MAN_PAGE: &'static str = /* @MANSTART{cp} */ r#"
+NAME
+    cp - copy files
+
+SYNOPSIS
+    cp SOURCE_FILE DESTINATION_FILES...
+
+DESCRIPTION
+    The cp utility copies the contents of the SOURCE_FILE to the DESTINATION_FILES. If multiple
+    destionation files are specified, then multiple copies of SOURCE_FILE are created.
+
+OPTIONS
+    --help, -h
+        print this message
+"#; /* @MANEND */
+
 fn main() {
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
     let mut stderr = stderr();
-    let ref src = env::args().nth(1).fail("no source argument.", &mut stderr);
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().nth(1) {
+            if arg == "--help" || arg == "-h" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
+    }
+
+    let ref src = env::args().nth(1).fail("No source argument. Use --help to see the usage.", &mut stderr);
     let dsts = env::args().skip(2);
 
     if dsts.len() < 1 {
-        fail("no destination arguments.", &mut stderr);
+        fail("No destination arguments. Use --help to see the usage.", &mut stderr);
     }
 
     let mut src_file = fs::File::open(src).try(&mut stderr);

--- a/src/bin/env.rs
+++ b/src/bin/env.rs
@@ -7,10 +7,36 @@ use std::io::{stdout, stderr, Write};
 use extra::io::WriteExt;
 use extra::option::OptionalExt;
 
+const MAN_PAGE: &'static str = /* @MANSTART{env} */ r#"
+NAME
+    env - print environment variables and their values
+
+SYNOPSIS
+    env [ -h | --help ]
+
+DESCRIPTION
+    env prints out the names and values of the variables in the environment, with one name=value pair per line.
+
+OPTIONS
+    -h
+    --help
+        Print this manual page.
+"#; /* @MANEND */
+
 fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().nth(1) {
+            if arg == "--help" || arg == "-h" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
+    }
 
     for (key, value) in env::vars() {
         stdout.write(key.as_bytes()).try(&mut stderr);

--- a/src/bin/mv.rs
+++ b/src/bin/mv.rs
@@ -4,13 +4,41 @@ extern crate extra;
 
 use std::env;
 use std::fs;
-use std::io::stderr;
+use std::io::{stderr, stdout, Write};
 use extra::option::OptionalExt;
 
+const MAN_PAGE: &'static str = /* @MANSTART{mv} */ r#"
+NAME
+    mv - move files
+
+SYNOPSIS
+    mv [ -h | --help ] SOURCE_FILE DESTINATION_FILE
+
+DESCRIPTION
+    The mv utility renames the file named by the SOURCE_FILE operand to the destination path named by the DESTINATION_FILE operand.
+
+OPTIONS
+    --help, -h
+        print this message
+"#; /* @MANEND */
+
 fn main() {
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
     let mut stderr = stderr();
-    let ref src = env::args().nth(1).fail("no source argument.", &mut stderr);
-    let ref dst = env::args().nth(2).fail("no destination argument.", &mut stderr);
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().nth(1) {
+            if arg == "--help" || arg == "-h" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
+    }
+
+    let ref src = env::args().nth(1).fail("No source argument. Use --help to see the usage.", &mut stderr);
+    let ref dst = env::args().nth(2).fail("No destination argument. Use --help to see the usage.", &mut stderr);
 
     fs::rename(src, dst).try(&mut stderr);
 }

--- a/src/bin/pwd.rs
+++ b/src/bin/pwd.rs
@@ -7,10 +7,36 @@ use std::io::{stdout, stderr, Write};
 
 use extra::option::OptionalExt;
 
+const MAN_PAGE: &'static str = /* @MANSTART{pwd} */ r#"
+NAME
+    pwd - return working directory name
+
+SYNOPSIS
+    pwd [ -h | --help ]
+
+DESCRIPTION
+    The pwd utility writes the absolute pathname of the current working directory to the standard output.
+
+OPTIONS
+    -h
+    --help
+        Print this manual page.
+"#; /* @MANEND */
+
 fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().nth(1) {
+            if arg == "--help" || arg == "-h" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
+    }
 
     let pwd = env::current_dir().try(&mut stderr);
 

--- a/src/bin/rm.rs
+++ b/src/bin/rm.rs
@@ -4,15 +4,42 @@ extern crate extra;
 
 use std::env;
 use std::fs;
-use std::io;
+use std::io::{stdout, stderr, Write};
 use extra::io::fail;
 use extra::option::OptionalExt;
 
+const MAN_PAGE: &'static str = /* @MANSTART{rm} */ r#"
+NAME
+    rm - delete files
+
+SYNOPSIS
+    rm [ -h | --help ] FILE...
+
+DESCRIPTION
+    The rm utility deletes the file named by the FILE operand. Multiple file names can be passed.
+
+OPTIONS
+    --help, -h
+        print this message
+"#; /* @MANEND */
+
 fn main() {
-    let mut stderr = io::stderr();
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().nth(1) {
+            if arg == "--help" || arg == "-h" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
+    }
 
     if env::args().count() < 2 {
-        fail("no arguments.", &mut stderr);
+        fail("No arguments. Use --help to see the usage.", &mut stderr);
     }
 
     for ref path in env::args().skip(1) {

--- a/src/bin/rmdir.rs
+++ b/src/bin/rmdir.rs
@@ -4,15 +4,42 @@ extern crate extra;
 
 use std::env;
 use std::fs;
-use std::io;
+use std::io::{stdout, stderr, Write};
 use extra::io::fail;
 use extra::option::OptionalExt;
 
+const MAN_PAGE: &'static str = /* @MANSTART{rmdir} */ r#"
+NAME
+    rmdir - delete directories
+
+SYNOPSIS
+    rmdir [ -h | --help ] DIRECTORY...
+
+DESCRIPTION
+    The rmdir utility deletes the directory named by the DIRECTORY operand. Multiple directories can be passed.
+
+OPTIONS
+    --help, -h
+        print this message
+"#; /* @MANEND */
+
 fn main() {
-    let mut stderr = io::stderr();
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().nth(1) {
+            if arg == "--help" || arg == "-h" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
+    }
 
     if env::args().count() < 2 {
-        fail("no arguments.", &mut stderr);
+        fail("No arguments. Use --help to see the usage.", &mut stderr);
     }
 
     for ref path in env::args().skip(1) {

--- a/src/bin/seq.rs
+++ b/src/bin/seq.rs
@@ -3,15 +3,42 @@
 extern crate extra;
 
 use std::env;
-use std::io::{stdout, stderr};
+use std::io::{stdout, stderr, Write};
 
 use extra::option::OptionalExt;
 use extra::io::{fail, WriteExt};
+
+const MAN_PAGE: &'static str = /* @MANSTART{seq} */ r#"
+NAME
+    seq - print sequence of numbers
+
+SYNOPSIS
+    seq [ -h | --help ] last
+
+DESCRIPTION
+    The seq utility prints a sequence of numbers, in increments of 1, one number per line,
+    from 1 to the number provided as the last operand.
+
+OPTIONS
+    -h
+    --help
+        Print this manual page.
+"#; /* @MANEND */
 
 fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().nth(1) {
+            if arg == "--help" || arg == "-h" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
+    }
 
     if env::args().count() < 2 {
         fail("missing value.", &mut stderr);

--- a/src/bin/yes.rs
+++ b/src/bin/yes.rs
@@ -3,14 +3,41 @@
 extern crate extra;
 
 use std::env;
-use std::io::{stdout, stderr};
+use std::io::{stdout, stderr, Write};
 use extra::io::WriteExt;
 use extra::option::OptionalExt;
+
+const MAN_PAGE: &'static str = /* @MANSTART{yes} */ r#"
+NAME
+    yes - print the letter y or a given word, forever.
+
+SYNOPSIS
+    seq [ [ -h | --help ] | [ word ] ]
+
+DESCRIPTION
+    The yes utility prints the word passed as an operand, forever. If no operand is passed, then
+    it defaults to the letter 'y'.
+
+OPTIONS
+    -h
+    --help
+        Print this manual page.
+"#; /* @MANEND */
 
 fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+    if env::args().count() == 2 {
+        if let Some(arg) = env::args().nth(1) {
+            if arg == "--help" || arg == "-h" {
+                stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
+                stdout.flush().try(&mut stderr);
+                return;
+            }
+        }
+    }
 
     let answer = env::args().skip(1).next();
     if let Some(x) = answer {


### PR DESCRIPTION
Added manual page to the following, which should close the issue #19:

- cp
- env
- mv
- pwd
- rmdir
- rm
- seq
- yes

All these tools print the man page when called with `-h` or `--help` operand.

It probably makes sense to squash the commits, committed separately just to make it easier to read.