### PR TITLE
Help Flags

### DIFF
--- a/src/bin/clear.rs
+++ b/src/bin/clear.rs
@@ -1,18 +1,40 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
-use std::io::{stdout, Write};
+extern crate extra;
+
+use std::env;
+use std::io::{stdout, stderr, Write};
+use extra::option::OptionalExt;
+use std::process::exit;
 
 const MAN_PAGE: &'static str = /* @MANSTART{clear} */ r#"
 NAME
     clear - clear the terminal screen
 
 SYNOPSIS
-    clear
+    clear [ -h | --help]
 
 DESCRIPTION
     Clear the screen, if possible
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
-    let _ = stdout().write(b"\x1B[2J");
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
+
+    let _ = stdout.write(b"\x1B[2J");
 }

--- a/src/bin/cp.rs
+++ b/src/bin/cp.rs
@@ -20,7 +20,8 @@ DESCRIPTION
     destionation files are specified, then multiple copies of SOURCE_FILE are created.
 
 OPTIONS
-    --help, -h
+    -h
+    --help
         print this message
 "#; /* @MANEND */
 

--- a/src/bin/date.rs
+++ b/src/bin/date.rs
@@ -1,26 +1,41 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
+use std::env;
 use std::io::{stdout, stderr, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 use extra::option::OptionalExt;
+use std::process::exit;
 
 const MAN_PAGE: &'static str = /* @MANSTART{date} */ r#"
 NAME
     date - prints the system time
-    
+
 SYNOPSIS
-    date
+    date [ -h | --help]
 
 DESCRIPTION
     Prints the system time and date
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     let time = SystemTime::now();
     let duration = time.duration_since(UNIX_EPOCH).try(&mut stderr);

--- a/src/bin/dmesg.rs
+++ b/src/bin/dmesg.rs
@@ -1,9 +1,11 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
+use std::env;
 use std::fs::File;
-use std::io;
+use std::io::{stdout, stderr, copy, Write};
+use std::process::exit;
 
 use extra::option::OptionalExt;
 
@@ -12,17 +14,30 @@ NAME
     dmesg - display the system message buffer
 
 SYNOPSIS
-    dmesg
+    dmesg [ -h | --help]
 
 DESCRIPTION
     Displays the contents of the system message buffer.
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = io::stdout();
+    let stdout = stdout();
     let mut stdout = stdout.lock();
-    let mut stderr = io::stderr();
+    let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     let mut file = File::open("syslog:").try(&mut stderr);
-    io::copy(&mut file, &mut stdout).try(&mut stderr);
+    copy(&mut file, &mut stdout).try(&mut stderr);
 }

--- a/src/bin/du.rs
+++ b/src/bin/du.rs
@@ -1,4 +1,4 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
@@ -6,16 +6,22 @@ use std::env;
 use std::fs;
 use std::io::{stdout, stderr, StdoutLock, Stderr, Write};
 use extra::option::OptionalExt;
+use std::process::exit;
 
 const MAN_PAGE: &'static str = /* @MANSTART{du} */ r#"
 NAME
     du - list directory content with sizes
 
 SYNOPSIS
-    du [FILE]...
+    du [ -h | --help][FILE]...
 
 DESCRIPTION
     List the name and size of the FILE(s), or the current directory
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn list_entry(path: &str, name: &str, stdout: &mut StdoutLock, stderr: &mut Stderr) {
@@ -65,6 +71,15 @@ fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     let mut args = env::args().skip(1);
     if let Some(ref x) = args.next() {

--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -1,17 +1,18 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
 use std::env;
 use std::io::{stdout, stderr, Write};
 use extra::option::OptionalExt;
+use std::process::exit;
 
 const MAN_PAGE: &'static str = /* @MANSTART{echo} */ r#"
 NAME
     echo - display a line of text
 
 SYNOPSIS
-    echo [STRING]...
+    echo [ -h | --help ] [STRING]...
 
 DESCRIPTION
     Print the STRING(s) to standard output.
@@ -30,6 +31,11 @@ fn main() {
     let mut newline = true;
 
     if let Some(arg) = args.nth(1) {
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
         if arg == "-n" {
             newline = false;
             if let Some(arg) = args.nth(0) {

--- a/src/bin/free.rs
+++ b/src/bin/free.rs
@@ -1,27 +1,42 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
+use std::env;
 use std::fs::File;
-use std::io;
+use std::io::{stderr, stdout, copy, Write};
 use extra::option::OptionalExt;
+use std::process::exit;
 
 const MAN_PAGE: &'static str = /* @MANSTART{free} */ r#"
 NAME
     free - display amount of free and used memory in the system
 
 SYNOPSIS
-    free
+    free [ -h | --help]
 
 DESCRIPTION
     Displays the total amount of free and used physical memory in the system
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = io::stdout();
+    let stdout = stdout();
     let mut stdout = stdout.lock();
-    let mut stderr = io::stderr();
+    let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     let mut file = File::open("memory:").try(&mut stderr);
-    io::copy(&mut file, &mut stdout).try(&mut stderr);
+    copy(&mut file, &mut stdout).try(&mut stderr);
 }

--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -1,4 +1,4 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
@@ -6,16 +6,22 @@ use std::env;
 use std::fs;
 use std::io::{stdout, stderr, StdoutLock, Stderr, Write};
 use extra::option::OptionalExt;
+use std::process::exit;
 
 const MAN_PAGE: &'static str = /* @MANSTART{ls} */ r#"
 NAME
     ls - list directory contents
 
 SYNOPSIS
-    ls [FILE]...
+    ls [ -h | --help ][FILE]...
 
 DESCRIPTION
     List information about the FILE(s), or the current directory
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn list_entry(name: &str, stdout: &mut StdoutLock, stderr: &mut Stderr) {
@@ -54,6 +60,14 @@ fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     let mut args = env::args().skip(1);
     if let Some(ref x) = args.next() {

--- a/src/bin/mkdir.rs
+++ b/src/bin/mkdir.rs
@@ -13,7 +13,7 @@ NAME
     mkdir - make directories
 
 SYNOPSIS
-    mkdir DIRECTORIES...
+    mkdir [ -h | --help ] DIRECTORIES...
 
 DESCRIPTION
     The mkdir utility creates the directories named as operands.

--- a/src/bin/printenv.rs
+++ b/src/bin/printenv.rs
@@ -11,13 +11,13 @@ use extra::option::OptionalExt;
 const MAN_PAGE: &'static str = /* @MANSTART{printenv} */ r#"
 NAME
     printenv - print environment variables
-    
+
 SYNOPSIS
     printenv [-h | --help] VARIABLES...
-    
+
 DESCRIPTION
     Print the values of the specified environment VARIABLES.
-    
+
 OPTIONS
     -h
     --help
@@ -41,6 +41,7 @@ fn main() {
             stdout.flush().try(&mut stderr);
             exit(0);
         }
+
         let value = env::var(arg).try(&mut stderr);
         stdout.writeln(value.as_bytes()).try(&mut stderr);
     }

--- a/src/bin/ps.rs
+++ b/src/bin/ps.rs
@@ -1,9 +1,11 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
+use std::env;
 use std::fs::File;
-use std::io;
+use std::io::{stdout, stderr, copy, Write};
+use std::process::exit;
 
 use extra::option::OptionalExt;
 
@@ -12,17 +14,30 @@ NAME
     ps - report a snapshot of the current processes
 
 SYNOPSIS
-    ps
+    ps [ -h | --help]
 
 DESCRIPTION
     Displays information about processes and threads that are currently active
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = io::stdout();
+    let stdout = stdout();
     let mut stdout = stdout.lock();
-    let mut stderr = io::stderr();
+    let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     let mut file = File::open("context:").try(&mut stderr);
-    io::copy(&mut file, &mut stdout).try(&mut stderr);
+    copy(&mut file, &mut stdout).try(&mut stderr);
 }

--- a/src/bin/realpath.rs
+++ b/src/bin/realpath.rs
@@ -1,10 +1,11 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
 use std::env;
 use std::fs;
-use std::io::{stdout, stderr};
+use std::io::{stdout, stderr, Write};
+use std::process::exit;
 
 use extra::io::{fail, WriteExt};
 use extra::option::OptionalExt;
@@ -14,16 +15,29 @@ NAME
     realpath - return the canonicalized absolute pathname
 
 SYNOPSIS
-    realpath FILE...
+    realpath [ -h | --help ] FILE...
 
 DESCRIPTION
-    realpath gets the aboslute pathname of FILE(s) and prints them out on seperate lines
+    realpath gets the absolute pathname of FILE(s) and prints them out on seperate lines
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     if env::args().count() < 2 {
         fail("no arguments.", &mut stderr);

--- a/src/bin/reset.rs
+++ b/src/bin/reset.rs
@@ -1,18 +1,41 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
-use std::io::{stdout, Write};
+extern crate extra;
+
+use std::env;
+use std::io::{stdout, stderr, Write};
+use std::process::exit;
+
+use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{reset} */ r#"
 NAME
     reset - terminal initialization
 
 SYNOPSIS
-    reset
+    reset [ -h | --help]
 
 DESCRIPTION
     Initialize the terminal, clearing the screen and setting all parameters to their default values
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
-    let _ = stdout().write(b"\x1Bc");
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
+
+    let _ = stdout.write(b"\x1Bc");
 }

--- a/src/bin/shutdown.rs
+++ b/src/bin/shutdown.rs
@@ -1,23 +1,42 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
+use std::env;
 use std::fs;
-use std::io;
+use std::io::{stderr, stdout, Write};
 use extra::option::OptionalExt;
+use std::process::exit;
 
 const MAN_PAGE: &'static str = /* @MANSTART{shutdown} */ r#"
 NAME
     shutdown - stop the system
 
 SYNOPSIS
-    shutdown
+    shutdown [ -h | -help ]
 
 DESCRIPTION
     Attempt to shutdown the system using ACPI. Failure will be logged to the terminal
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
-    let mut stderr = io::stderr();
+
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
+
     fs::File::create("acpi:off").try(&mut stderr);
 }

--- a/src/bin/time.rs
+++ b/src/bin/time.rs
@@ -1,4 +1,4 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
@@ -7,22 +7,36 @@ use std::io::{stdout, stderr, Write};
 use std::process::Command;
 use std::time::Instant;
 use extra::option::OptionalExt;
+use std::process::exit;
 
 const MAN_PAGE: &'static str = /* @MANSTART{time} */ r#"
 NAME
     time - timer for commands
-    
+
 SYNOPSIS
-    time [COMMAND] [ARGUEMENT]...
-    
+    time [ -h | --help ][COMMAND] [ARGUEMENT]...
+
 DESCRIPTION
     Runs the command taken as the first arguement and outputs the time the command took to execute.
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     let time = Instant::now();
 

--- a/src/bin/touch.rs
+++ b/src/bin/touch.rs
@@ -1,10 +1,11 @@
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate extra;
 
 use std::env;
 use std::fs::File;
-use std::io;
+use std::io::{stdout, stderr, Write};
+use std::process::exit;
 use extra::option::OptionalExt;
 use extra::io::fail;
 
@@ -13,14 +14,29 @@ NAME
     touch - create file(s)
 
 SYNOPSIS
-    touch FILE...
+    touch [ -h | --help ] FILE...
 
 DESCRIPTION
     Create the FILE(s) arguments provided
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
 "#; /* @MANEND */
 
 fn main() {
-    let mut stderr = io::stderr();
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
+
+    for arg in env::args().skip(1){
+        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+            stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+            stdout.flush().try(&mut stderr);
+            exit(0);
+        }
+    }
 
     if env::args().count() < 2 {
         fail("no arguments.", &mut stderr);


### PR DESCRIPTION
Added help (`-h` and `--help`) flags to all coreutils that were missing them except `true` and `false` as well as updated all the man pages to fit the new functionality.

`#![deny(warings)]` was now reactivated as well for all altered files, as the unused `const` warning is no longer happening.