### PR TITLE
Human readable sizes WIP

### DIFF
--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -55,9 +55,17 @@ fn list_dir(path: &str, long_format: bool, human_readable: bool, string: &mut St
 
                 let metadata = fs::metadata(entry_path).try(stderr);
                 if human_readable {
-                    string.push_str(&format!("{:>7o} {:>5} {:>5} {} ", metadata.mode(), metadata.uid(), metadata.gid(), to_human_readable_string(metadata.size())));
+                    string.push_str(&format!("{:>7o} {:>5} {:>5} {} ",
+                                             metadata.mode(),
+                                             metadata.uid(),
+                                             metadata.gid(),
+                                             to_human_readable_string(metadata.size())));
                 } else {
-                    string.push_str(&format!("{:>7o} {:>5} {:>5} {:>8} ", metadata.mode(), metadata.uid(), metadata.gid(), metadata.size()));
+                    string.push_str(&format!("{:>7o} {:>5} {:>5} {:>8} ",
+                                             metadata.mode(),
+                                             metadata.uid(),
+                                             metadata.gid(),
+                                             metadata.size()));
                 }
             }
             string.push_str(entry);
@@ -66,9 +74,17 @@ fn list_dir(path: &str, long_format: bool, human_readable: bool, string: &mut St
     } else {
         if long_format {
             if human_readable {
-                string.push_str(&format!("{:>7o} {:>5} {:>5} {} ", metadata.mode(), metadata.uid(), metadata.gid(), to_human_readable_string(metadata.size())));
+                string.push_str(&format!("{:>7o} {:>5} {:>5} {} ",
+                                         metadata.mode(),
+                                         metadata.uid(),
+                                         metadata.gid(),
+                                         to_human_readable_string(metadata.size())));
             } else {
-                string.push_str(&format!("{:>7o} {:>5} {:>5} {:>8} ", metadata.mode(), metadata.uid(), metadata.gid(), metadata.size()));
+                string.push_str(&format!("{:>7o} {:>5} {:>5} {:>8} ",
+                                         metadata.mode(),
+                                         metadata.uid(),
+                                         metadata.gid(),
+                                         metadata.size()));
             }
         }
         string.push_str(path);
@@ -85,7 +101,9 @@ fn to_human_readable_string(size: u64) -> String {
     let units = ["", "K", "M", "G", "T", "P", "E"];
 
     let digit_groups = (sizef.log10() / 1024f64.log10()) as i32;
-    format!("{:.1}{}", sizef / 1024f64.powi(digit_groups), units[digit_groups as usize])
+    format!("{:.1}{}",
+            sizef / 1024f64.powi(digit_groups),
+            units[digit_groups as usize])
 }
 
 fn main() {
@@ -127,9 +145,9 @@ fn test_human_readable() {
     assert_eq!(to_human_readable_string(333), "333");
     assert_eq!(to_human_readable_string(1024 * 1), "1.0K");
     assert_eq!(to_human_readable_string(1024 * 1 + 100), "1.1K");
-    assert_eq!(to_human_readable_string(1024 * 1024 * 2), "2.0M");
-    assert_eq!(to_human_readable_string(1024 * 1024 * 1024 * 3), "3.0G");
-    assert_eq!(to_human_readable_string(1024 * 1024 * 1024 * 1024 * 4), "4.0T");
-    assert_eq!(to_human_readable_string(1024 * 1024 * 1024 * 1024 * 1024 * 5), "5.0P");
-    assert_eq!(to_human_readable_string(1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 6), "6.0E");
+    assert_eq!(to_human_readable_string(1024u64.pow(2) * 2), "2.0M");
+    assert_eq!(to_human_readable_string(1024u64.pow(3) * 3), "3.0G");
+    assert_eq!(to_human_readable_string(1024u64.pow(4) * 4), "4.0T");
+    assert_eq!(to_human_readable_string(1024u64.pow(5) * 5), "5.0P");
+    assert_eq!(to_human_readable_string(1024u64.pow(6) * 6), "6.0E");
 }

--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -15,18 +15,21 @@ NAME
     ls - list directory contents
 
 SYNOPSIS
-    ls [ -h | --help ][FILE]...
+    ls [ -h | --help | -l ][FILE]...
 
 DESCRIPTION
     List information about the FILE(s), or the current directory
 
 OPTIONS
     -h
+        with -l, print human readable sizes
     --help
         display this help and exit
+    -l
+        use a long listing format
 "#; /* @MANEND */
 
-fn list_dir(path: &str, long_format: bool, string: &mut String, stderr: &mut Stderr) {
+fn list_dir(path: &str, long_format: bool, human_readable: bool, string: &mut String, stderr: &mut Stderr) {
     let metadata = fs::metadata(path).try(stderr);
     if metadata.is_dir() {
         let read_dir = Path::new(path).read_dir().try(stderr);
@@ -51,18 +54,38 @@ fn list_dir(path: &str, long_format: bool, string: &mut String, stderr: &mut Std
                 entry_path.push_str(&entry);
 
                 let metadata = fs::metadata(entry_path).try(stderr);
-                string.push_str(&format!("{:>7o} {:>5} {:>5} {:>8} ", metadata.mode(), metadata.uid(), metadata.gid(), metadata.size()/1024));
+                if human_readable {
+                    string.push_str(&format!("{:>7o} {:>5} {:>5} {} ", metadata.mode(), metadata.uid(), metadata.gid(), to_human_readable_string(metadata.size())));
+                } else {
+                    string.push_str(&format!("{:>7o} {:>5} {:>5} {:>8} ", metadata.mode(), metadata.uid(), metadata.gid(), metadata.size()));
+                }
             }
             string.push_str(entry);
             string.push('\n');
         }
     } else {
         if long_format {
-            string.push_str(&format!("{:>7o} {:>5} {:>5} {:>8} ", metadata.mode(), metadata.uid(), metadata.gid(), metadata.size()/1024));
+            if human_readable {
+                string.push_str(&format!("{:>7o} {:>5} {:>5} {} ", metadata.mode(), metadata.uid(), metadata.gid(), to_human_readable_string(metadata.size())));
+            } else {
+                string.push_str(&format!("{:>7o} {:>5} {:>5} {:>8} ", metadata.mode(), metadata.uid(), metadata.gid(), metadata.size()));
+            }
         }
         string.push_str(path);
         string.push('\n');
     }
+}
+
+fn to_human_readable_string(size: u64) -> String {
+    if size < 1024 {
+        return format!("{}", size);
+    }
+
+    let sizef = size as f64;
+    let units = ["", "K", "M", "G", "T", "P", "E"];
+
+    let digit_groups = (sizef.log10() / 1024f64.log10()) as i32;
+    format!("{:.1}{}", sizef / 1024f64.powi(digit_groups), units[digit_groups as usize])
 }
 
 fn main() {
@@ -71,14 +94,17 @@ fn main() {
     let mut stderr = stderr();
 
     let mut long_format = false;
+    let mut human_readable = false;
     let mut args = Vec::new();
     for arg in env::args().skip(1) {
-        if arg.as_str() == "-h" || arg.as_str() == "--help" {
+        if arg.as_str() == "--help" {
             stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
             stdout.flush().try(&mut stderr);
             exit(0);
         } else if arg.as_str() == "-l" {
             long_format = true;
+        } else if arg.as_str() == "-h" {
+            human_readable = true;
         } else {
             args.push(arg);
         }
@@ -86,11 +112,24 @@ fn main() {
 
     let mut string = String::new();
     if args.is_empty() {
-        list_dir(".", long_format, &mut string, &mut stderr);
+        list_dir(".", long_format, human_readable, &mut string, &mut stderr);
     } else {
         for dir in args {
-            list_dir(&dir, long_format, &mut string, &mut stderr);
+            list_dir(&dir, long_format, human_readable, &mut string, &mut stderr);
         }
     }
     stdout.write(string.as_bytes()).try(&mut stderr);
+}
+
+#[test]
+fn test_human_readable() {
+    assert_eq!(to_human_readable_string(0), "0");
+    assert_eq!(to_human_readable_string(333), "333");
+    assert_eq!(to_human_readable_string(1024 * 1), "1.0K");
+    assert_eq!(to_human_readable_string(1024 * 1 + 100), "1.1K");
+    assert_eq!(to_human_readable_string(1024 * 1024 * 2), "2.0M");
+    assert_eq!(to_human_readable_string(1024 * 1024 * 1024 * 3), "3.0G");
+    assert_eq!(to_human_readable_string(1024 * 1024 * 1024 * 1024 * 4), "4.0T");
+    assert_eq!(to_human_readable_string(1024 * 1024 * 1024 * 1024 * 1024 * 5), "5.0P");
+    assert_eq!(to_human_readable_string(1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 6), "6.0E");
 }

--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -97,13 +97,12 @@ fn to_human_readable_string(size: u64) -> String {
         return format!("{}", size);
     }
 
-    let sizef = size as f64;
-    let units = ["", "K", "M", "G", "T", "P", "E"];
+    static UNITS: [&'static str; 7] = ["", "K", "M", "G", "T", "P", "E"];
 
-    let digit_groups = (sizef.log10() / 1024f64.log10()) as i32;
+    let digit_groups = ((64 - size.leading_zeros()) / 10) as i32;
     format!("{:.1}{}",
-            sizef / 1024f64.powi(digit_groups),
-            units[digit_groups as usize])
+            size as f64 / 1024f64.powi(digit_groups),
+            UNITS[digit_groups as usize])
 }
 
 fn main() {
@@ -142,9 +141,9 @@ fn main() {
 #[test]
 fn test_human_readable() {
     assert_eq!(to_human_readable_string(0), "0");
-    assert_eq!(to_human_readable_string(333), "333");
-    assert_eq!(to_human_readable_string(1024 * 1), "1.0K");
-    assert_eq!(to_human_readable_string(1024 * 1 + 100), "1.1K");
+    assert_eq!(to_human_readable_string(1023), "1023");
+    assert_eq!(to_human_readable_string(1024), "1.0K");
+    assert_eq!(to_human_readable_string(1024 + 100), "1.1K");
     assert_eq!(to_human_readable_string(1024u64.pow(2) * 2), "2.0M");
     assert_eq!(to_human_readable_string(1024u64.pow(3) * 3), "3.0G");
     assert_eq!(to_human_readable_string(1024u64.pow(4) * 4), "4.0T");


### PR DESCRIPTION
Hi, I changed `ls.rs` to print in human readable sizes. The `to_human_readable_string` function can be reused in `du.rs`, but I don't want to just copy is there. Where is a good location to put `to_human_readable_string`?

fixes #76