### PR TITLE
add syscall dep for `df` compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ path = "src/bin/dd.rs"
 name = "df"
 path = "src/bin/df.rs"
 
+[dependencies]
+redox_syscall = { path = "../../syscall" }
+
 [[bin]]
 name = "du"
 path = "src/bin/du.rs"


### PR DESCRIPTION
add syscall dep for `df` compile error