### PR TITLE
Preparse the arguments to error out early when needed

### DIFF
--- a/src/bin/sleep.rs
+++ b/src/bin/sleep.rs
@@ -56,10 +56,14 @@ fn main() {
     }
 
     if !parser.args.is_empty() {
-        thread::sleep(Duration::from_millis(argument_to_ms(&parser.args[0], &mut stderr)));
-        for argument in &parser.args[1..] {
-            thread::sleep(Duration::from_millis(argument_to_ms(&argument, &mut stderr)));
+        let sleep_times_in_ms = parser.args.iter()
+            .map(|argument| argument_to_ms(&argument, &mut stderr))
+            .collect::<Vec<_>>();
+
+        for sleep_time in sleep_times_in_ms {
+            thread::sleep(Duration::from_millis(sleep_time));
         }
+
     } else {
         stderr.write(MISSING_OPERAND.as_bytes()).try(&mut stderr);
         stderr.write(HELP_INFO.as_bytes()).try(&mut stderr);


### PR DESCRIPTION
sleep.rs parses it's arguments and waits the according time sequentially, in a way that if an invalid time interval appears after valid time intervals, it errors out during execution.
For exemple, currently, the command

    sleep 1m redox 30s
will wait 1 minute then exit with an error saying 'redox' is not a valid interval.

This PR makes it so sleep.rs parses all it's arguments first, errors out if needed, and only then starts waiting.