### PR TITLE
add -R(recursive) option support and output a human-readable file mod…

### DIFF
--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -34,6 +34,8 @@ OPTIONS
         display this help and exit
     -l
         use a long listing format
+    -r, --reverse
+        reverse order while sorting
     -R, --recursive
         list subdirectories recursively
 "#; /* @MANEND */
@@ -98,7 +100,11 @@ fn list_dir(path: &str, parser: &ArgParser, stdout: &mut StdoutLock, stderr: &mu
             file_name
         }).collect();
 
-        entries.sort();
+        if parser.found(&'r') || parser.found("reverse") {
+            entries.sort_by(|a, b| b.cmp(a));
+        } else {
+            entries.sort_by(|a, b| a.cmp(b));
+        }
 
         for entry in entries.iter() {
             let mut entry_path = path.to_owned();
@@ -125,6 +131,7 @@ fn main() {
     let mut parser = ArgParser::new(4)
         .add_flag("l", "long-format")
         .add_flag("h", "human-readable")
+        .add_flag("r", "reverse")
         .add_flag("R", "recursive")
         .add_flag("", "help");
     parser.parse(env::args());


### PR DESCRIPTION
add -R(recursive) option support and output a human-readable file mode like -rwxr-xr-x

```
-rw-r--r--  1000  1000       18 .gitignore
-rw-r--r--  1000  1000       75 .travis.yml
-rw-r--r--  1000  1000      720 Cargo.lock
-rw-r--r--  1000  1000     2326 Cargo.toml
-rw-r--r--  1000  1000     1092 LICENSE
-rw-r--r--  1000  1000      695 README.md
drwxr-xr-x  1000  1000     4096 src
drwxr-xr-x  1000  1000     4096 src/bin
-rw-r--r--  1000  1000     5935 src/bin/basename.rs
-rw-r--r--  1000  1000    12861 src/bin/cat.rs
-rw-r--r--  1000  1000     1433 src/bin/chmod.rs
-rw-r--r--  1000  1000      894 src/bin/clear.rs
-rw-r--r--  1000  1000     2234 src/bin/cp.rs
-rw-r--r--  1000  1000    19245 src/bin/cut.rs
-rw-r--r--  1000  1000     2152 src/bin/date.rs
-rw-r--r--  1000  1000     3515 src/bin/dd.rs
-rw-r--r--  1000  1000     3125 src/bin/df.rs
-rw-r--r--  1000  1000     2848 src/bin/du.rs
```