### PR TITLE
Makes dd use ArgParser

### DIFF
--- a/src/bin/dd.rs
+++ b/src/bin/dd.rs
@@ -44,8 +44,8 @@ fn main() {
 
     let mut parser = ArgParser::new(5)
         .add_flag(&["h", "help"])
-        .add_opt("", "bs")
-        .add_opt("", "count")
+        .add_opt_default("", "bs", "512")
+        .add_opt_default("", "count", "-1")
         .add_opt("", "if")
         .add_opt("", "of");
     parser.parse(env::args());
@@ -60,26 +60,8 @@ fn main() {
         fail("missing if or of", &mut stderr);
     }
 
-    let bs: usize = 
-        if let Some(num) = parser.get_opt("bs") {
-            match num.parse() {
-              Ok(n) => n,
-              Err(_) => 512,
-            }
-        }
-        else {
-            512
-        };
-    let count = 
-        if let Some(num) = parser.get_opt("count") {
-            match num.parse() {
-              Ok(n) => n,
-              Err(_) => -1,
-            }
-        }
-        else {
-            -1
-        };
+    let bs: usize = parser.get_opt("bs").unwrap().parse::<usize>().unwrap();
+    let count = parser.get_opt("count").unwrap().parse::<i32>().unwrap();
 
     let in_path: String = parser.get_opt("if").unwrap();
     let out_path = parser.get_opt("of").unwrap();

--- a/src/bin/dd.rs
+++ b/src/bin/dd.rs
@@ -44,27 +44,27 @@ fn main() {
 
     let mut parser = ArgParser::new(5)
         .add_flag(&["h", "help"])
-        .add_opt_default("", "bs", "512")
-        .add_opt_default("", "count", "-1")
-        .add_opt("", "if")
-        .add_opt("", "of");
+        .add_setting_default("bs", "512")
+        .add_setting_default("count", "-1")
+        .add_setting("if")
+        .add_setting("of");
     parser.parse(env::args());
 
     if parser.found("help") {
         stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
         stdout.flush().try(&mut stderr);
         exit(0);
-    }
+    } else if !parser.found("if") {
+        fail("missing if argument", &mut stderr);
+    } else if !parser.found("of") {
+        fail("missing of argument", &mut stderr);
+    } 
 
-    if !parser.found("if") || !parser.found("of") {
-        fail("missing if or of", &mut stderr);
-    }
+    let bs: usize = parser.get_setting("bs").unwrap().parse::<usize>().unwrap();
+    let count = parser.get_setting("count").unwrap().parse::<i32>().unwrap();
 
-    let bs: usize = parser.get_opt("bs").unwrap().parse::<usize>().unwrap();
-    let count = parser.get_opt("count").unwrap().parse::<i32>().unwrap();
-
-    let in_path: String = parser.get_opt("if").unwrap();
-    let out_path = parser.get_opt("of").unwrap();
+    let in_path: String = parser.get_setting("if").unwrap();
+    let out_path = parser.get_setting("of").unwrap();
     let status = 1;
 
     let mut input = File::open(in_path).expect("dd: failed to open if");

--- a/src/bin/dd.rs
+++ b/src/bin/dd.rs
@@ -1,41 +1,90 @@
+#![deny(warnings)]
 extern crate coreutils;
+extern crate extra;
 
-
-use coreutils::to_human_readable_string;
 use std::env;
 use std::fs::File;
-use std::io::{stderr, Read, Write};
+use std::io::{stderr, stdout, Read, Write};
 use std::time::Instant;
+use std::process::exit;
+use coreutils::{ArgParser, to_human_readable_string};
+use extra::option::OptionalExt;
+use extra::io::fail;
+
+const MAN_PAGE: &'static str = /* @MANSTART{du} */ r#"
+NAME
+    dd - copy a file
+
+SYNOPSIS
+    dd [ -h | --help ] if=[FILE] of=[FILE]
+
+DESCRIPTION
+    The dd tool copies from a file to another file in 512-byte block sizes
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
+
+    bs=n
+        set input and output block size to n bytes
+    count=n
+        copy only n blocks
+    if=file
+        read from file instead of standard input
+    of=file
+        write output to file instead of standard out
+
+"#; /* @MANEND */
 
 fn main() {
-    let stderr = stderr();
-    let mut stderr = stderr.lock();
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
 
-    let mut bs = 512;
-    let mut count = None;
-    let mut in_path = String::new();
-    let mut out_path = String::new();
-    let mut status = 1;
-    for arg in env::args().skip(1) {
-        if arg.starts_with("bs=") {
-            bs = arg[3..].parse::<usize>().expect("dd: bs is not a number");
-        } else if arg.starts_with("count=") {
-            count = Some(arg[6..].parse::<usize>().expect("dd: count is not a number"));
-        } else if arg.starts_with("if=") {
-            in_path = arg[3..].to_string();
-        } else if arg.starts_with("of=") {
-            out_path = arg[3..].to_string();
-        } else if arg.starts_with("status=") {
-            match &arg[7..] {
-                "none" => status = 0,
-                "noxfer" => status = 1,
-                "progress" => status = 2,
-                unknown => panic!("dd: status: unrecognized argument '{}'", unknown)
-            }
-        } else {
-            panic!("dd: unrecognized operand '{}'", arg);
-        }
+    let mut parser = ArgParser::new(5)
+        .add_flag(&["h", "help"])
+        .add_opt("", "bs")
+        .add_opt("", "count")
+        .add_opt("", "if")
+        .add_opt("", "of");
+    parser.parse(env::args());
+    parser.parse_dd(env::args());
+
+    if parser.found("help") {
+        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+        stdout.flush().try(&mut stderr);
+        exit(0);
     }
+
+    if !parser.found("if") || !parser.found("of") {
+        fail("missing if or of", &mut stderr);
+    }
+
+    let bs: usize = 
+        if let Some(num) = parser.get_opt("bs") {
+            match num.parse() {
+              Ok(n) => n,
+              Err(_) => 512,
+            }
+        }
+        else {
+            512
+        };
+    let count = 
+        if let Some(num) = parser.get_opt("count") {
+            match num.parse() {
+              Ok(n) => n,
+              Err(_) => -1,
+            }
+        }
+        else {
+            -1
+        };
+
+    let in_path: String = parser.get_opt("if").unwrap();
+    let out_path = parser.get_opt("of").unwrap();
+    let status = 1;
 
     let mut input = File::open(in_path).expect("dd: failed to open if");
     let mut output = File::create(out_path).expect("dd: failed to open of");
@@ -59,7 +108,7 @@ fn main() {
             running = false;
         } else {
             in_recs += 1;
-            if let Some(count) = count {
+            if count != -1 {
                 if in_recs >= count {
                     running = false;
                 }

--- a/src/bin/dd.rs
+++ b/src/bin/dd.rs
@@ -49,7 +49,6 @@ fn main() {
         .add_opt("", "if")
         .add_opt("", "of");
     parser.parse(env::args());
-    parser.parse_dd(env::args());
 
     if parser.found("help") {
         stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,18 +226,7 @@ impl ArgParser {
                     }
                 }
             }
-            else {
-                self.args.push(arg);
-            }
-        }
-    }
-
-    /// Parse dd opts
-    pub fn parse_dd<A: Iterator<Item=String>>(&mut self, args: A) {
-        let mut args = args.skip(1);
-        while let Some(arg) = args.next() {
-            if arg.starts_with("if") || arg.starts_with("of") ||
-                arg.starts_with("bs") || arg.starts_with("count") {
+            else if arg.contains("=") {
                 if arg.is_empty() {
                     //Arg `--` means we are done parsing args, collect the rest
                     self.args.extend(args);
@@ -261,9 +250,8 @@ impl ArgParser {
                         _ => self.invalid.push(Param::Long(lhs.to_owned())),
                     }
                 }
-                
             }
-            else {  
+            else {
                 self.args.push(arg);
             }
         }
@@ -416,15 +404,13 @@ mod tests {
     }
 
     #[test]
-    fn dd_opts() {
+    fn dd_style_opts() {
         let args = vec![String::from("binname"), String::from("-h"), String::from("if=bar"), String::from("of=foo")];
         let mut parser = ArgParser::new(4);
         parser = parser.add_flag(&["h"])
                        .add_opt("", "if")
                        .add_opt("", "of");
-        let args_iter = args.into_iter();
-        parser.parse(args_iter.clone());
-        parser.parse_dd(args_iter);
+        parser.parse(args.into_iter());
         assert!(parser.found(&'h'));
         assert!(parser.get_opt("if") == Some(String::from("bar")));
         assert!(parser.get_opt("of") == Some(String::from("foo")));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,11 +66,19 @@ enum Value {
         rhs: Rhs<Rc<RefCell<String>>>,
         found: bool,
     },
+    Setting {
+        rhs: Rhs<Rc<RefCell<String>>>,
+        found: bool,
+    },
 }
 
 impl Value {
     fn new_opt(value: Rc<RefCell<String>>) -> Self {
         Value::Opt { rhs: Rhs::new(value), found: false }
+    }
+
+    fn new_setting(value: Rc<RefCell<String>>) -> Self {
+        Value::Setting { rhs: Rhs::new(value), found: false }
     }
 }
 
@@ -158,6 +166,34 @@ impl ArgParser {
         self
     }
 
+    /// Builder method for adding settings
+    ///
+    /// Settings are parameters that hold assigned values. They are used
+    /// in some applications such as dd
+    ///
+    /// For example
+    /// > dd if=/path/file
+    ///   ^  ^    
+    ///   |  |    
+    ///   |  |    
+    ///   |  `-- The setting set to /path/file
+    ///   `-- The command to list files.
+    pub fn add_setting(mut self, setting: &str) -> Self {
+        let value = Rc::new(RefCell::new("".to_owned()));
+        if !setting.is_empty() {
+            self.params.insert(Param::Long(setting.to_owned()), Value::new_setting(value));
+        }
+        self
+    }
+
+    pub fn add_setting_default(mut self, setting: &str, default: &str) -> Self {
+        let value = Rc::new(RefCell::new(default.to_owned()));
+        if !setting.is_empty() {
+            self.params.insert(Param::Long(setting.to_owned()), Value::new_setting(value));
+        }
+        self
+    }
+
     /// Start parsing user inputted args for which flags and opts are used at
     /// runtime. The rest of the args that are not associated to opts get added
     /// to `ArgParser.args`.
@@ -222,6 +258,7 @@ impl ArgParser {
                             }
                             break;
                         }
+                        Some(&mut Value::Setting{..}) => self.invalid.push(Param::Short(ch)),
                         None => self.invalid.push(Param::Short(ch)),
                     }
                 }
@@ -236,7 +273,7 @@ impl ArgParser {
                     let (lhs, rhs) = arg.split_at(i);
                     let rhs = &rhs[1..]; // slice off the `=` char
                     match self.params.get_mut(lhs) {
-                        Some(&mut Value::Opt { rhs: ref mut opt_rhs, ref mut found }) => {
+                        Some(&mut Value::Setting { rhs: ref mut opt_rhs, ref mut found }) => {
                             if (*opt_rhs.value).borrow().is_empty() {
                                 opt_rhs.occurrences = 1;
                             }
@@ -275,6 +312,7 @@ impl ArgParser {
         match self.params.get(name) {
             Some(&Value::Flag(ref rhs)) => *(*rhs.value).borrow_mut(),
             Some(&Value::Opt { found, .. }) => found,
+            Some(&Value::Setting { found, .. }) => found,
             _ => false,
         }
     }
@@ -307,6 +345,17 @@ impl ArgParser {
         where Param: Borrow<O>
     {
         if let Some(&Value::Opt { ref rhs, .. }) = self.params.get(opt) {
+            return Some((*rhs.value).borrow().clone());
+        }
+        None
+    }
+
+    /// Get the value of an Setting. If it has been set or defaulted, it will return a `Some(String)`
+    /// value otherwise it will return None.
+    pub fn get_setting<O: Hash + Eq + ?Sized>(&self, setting: &O) -> Option<String>
+        where Param: Borrow<O>
+    {
+        if let Some(&Value::Setting { ref rhs, .. }) = self.params.get(setting) {
             return Some((*rhs.value).borrow().clone());
         }
         None
@@ -404,15 +453,15 @@ mod tests {
     }
 
     #[test]
-    fn dd_style_opts() {
-        let args = vec![String::from("binname"), String::from("-h"), String::from("if=bar"), String::from("of=foo")];
+    fn settings() {
+        let args = vec![String::from("binname"), String::from("-h"), String::from("if=bar")];
         let mut parser = ArgParser::new(4);
         parser = parser.add_flag(&["h"])
-                       .add_opt("", "if")
-                       .add_opt("", "of");
+                       .add_setting("if")
+                       .add_setting_default("of", "foo");
         parser.parse(args.into_iter());
-        assert!(parser.found(&'h'));
-        assert!(parser.get_opt("if") == Some(String::from("bar")));
-        assert!(parser.get_opt("of") == Some(String::from("foo")));
+        assert!(parser.found("if"));
+        assert!(parser.get_setting("if") == Some(String::from("bar")));
+        assert!(parser.get_setting("of") == Some(String::from("foo")));
     }
 }


### PR DESCRIPTION
`dd` now adheres to ArgParser. All core utilities should now use ArgParser.

More work needs to be done to address #126.