### PR TITLE
Add new flags and functionality to ls command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 extra = { git = "https://github.com/redox-os/libextra.git" }
 redox_syscall = "0.1"
 walkdir = "1"
+chrono = "0.3"
 
 [lib]
 path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.1.0"
 extra = { git = "https://github.com/redox-os/libextra.git" }
 redox_syscall = "0.1"
 walkdir = "1"
-chrono = "0.3"
 
 [lib]
 path = "src/lib.rs"

--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -16,7 +16,7 @@ use coreutils::{ArgParser, to_human_readable_string, system_time_to_string};
 use extra::option::OptionalExt;
 
 
-const MAN_PAGE: &'static str = r#"
+const MAN_PAGE: &'static str = /* @MANSTART{ls} */ r#"
 NAME
     ls - list directory contents
 

--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+extern crate chrono;
 
 extern crate coreutils;
 extern crate extra;
@@ -219,4 +220,14 @@ fn test_human_readable() {
     assert_eq!(to_human_readable_string(1024u64.pow(4) * 4), "4.0T");
     assert_eq!(to_human_readable_string(1024u64.pow(5) * 5), "5.0P");
     assert_eq!(to_human_readable_string(1024u64.pow(6) * 6), "6.0E");
+}
+
+#[test]
+fn test_system_time_to_string() {
+    use std::time::SystemTime;
+    use chrono::prelude::{DateTime,UTC};
+
+    let system_time_now = SystemTime::now();
+    let utc_now: DateTime<UTC> = UTC::now();
+    assert_eq!(system_time_to_string(system_time_now), utc_now.format("%Y-%m-%d %H:%M:%S").to_string());
 }

--- a/src/bin/ls.rs
+++ b/src/bin/ls.rs
@@ -13,7 +13,7 @@ use std::os::unix::fs::MetadataExt;
 
 use std::process::exit;
 
-use coreutils::{ArgParser, to_human_readable_string, system_time_to_string};
+use coreutils::{ArgParser, to_human_readable_string, system_time_to_utc_string};
 use extra::option::OptionalExt;
 
 
@@ -40,11 +40,11 @@ OPTIONS
         reverse order while sorting
     -R, --recursive
         list subdirectories recursively
-    --modified-date
+    --mdate --modified-date
         display date of last modification
-    --accessed-date
+    --adate --accessed-date
         display date of last access
-    --created-date
+    --cdate --created-date
         display date of creation
 
 "#; /* @MANEND */
@@ -103,13 +103,13 @@ fn print_item(item_path: &str, parser: &ArgParser, stdout: &mut StdoutLock, stde
         }
     }
     if parser.found("modified-date") || parser.found("long-format") {
-        stdout.write(&format!("{:>20} ", system_time_to_string(metadata.modified().expect("can't get modification date from file metadata"))).as_bytes()).try(stderr);
+        stdout.write(&format!("{:>20} ", system_time_to_utc_string(metadata.modified().expect("can't get modification date from file metadata"))).as_bytes()).try(stderr);
     }
     if parser.found("created-date") {
-        stdout.write(&format!("{:>20} ", system_time_to_string(metadata.created().expect("can't get creation date from file metadata"))).as_bytes()).try(stderr);
+        stdout.write(&format!("{:>20} ", system_time_to_utc_string(metadata.created().expect("can't get creation date from file metadata"))).as_bytes()).try(stderr);
     }
     if parser.found("accessed-date") {
-        stdout.write(&format!("{:>20} ", system_time_to_string(metadata.accessed().expect("can't get access date from file metadata"))).as_bytes()).try(stderr);
+        stdout.write(&format!("{:>20} ", system_time_to_utc_string(metadata.accessed().expect("can't get access date from file metadata"))).as_bytes()).try(stderr);
     }
 
     if item_path.starts_with("./") {
@@ -187,9 +187,9 @@ fn main() {
         .add_flag(&["h", "human-readable"])
         .add_flag(&["r", "reverse"])
         .add_flag(&["R", "recursive"])
-        .add_flag(&["", "modified-date"])
-        .add_flag(&["", "accessed-date"])
-        .add_flag(&["", "created-date"])
+        .add_flag(&["mdate", "modified-date"])
+        .add_flag(&["adate", "accessed-date"])
+        .add_flag(&["cdate", "created-date"])
         .add_flag(&["", "help"]);
     parser.parse(env::args());
 
@@ -223,11 +223,11 @@ fn test_human_readable() {
 }
 
 #[test]
-fn test_system_time_to_string() {
+fn test_system_time_to_utc_string() {
     use std::time::SystemTime;
     use chrono::prelude::{DateTime,UTC};
 
     let system_time_now = SystemTime::now();
     let utc_now: DateTime<UTC> = UTC::now();
-    assert_eq!(system_time_to_string(system_time_now), utc_now.format("%Y-%m-%d %H:%M:%S").to_string());
+    assert_eq!(system_time_to_utc_string(system_time_now), utc_now.format("%Y-%m-%d %H:%M:%S").to_string());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,7 @@ impl ArgParser {
     }
 }
 
-pub fn system_time_to_string(system_time: SystemTime) -> String {
+pub fn system_time_to_utc_string(system_time: SystemTime) -> String {
     let timestamp = system_time.duration_since(UNIX_EPOCH).expect("can't get duration since unix epoch");
     NaiveDateTime::from_timestamp(timestamp.as_secs() as i64, 0).to_string()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
+extern crate chrono;
+
 use std::borrow::Borrow;
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
-use std::hash::{Hash,Hasher};
+use std::hash::{Hash, Hasher};
 use std::rc::Rc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use chrono::NaiveDateTime;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// The parameter styles for short, e.g. `-s`,
@@ -396,6 +400,11 @@ impl ArgParser {
         output.push('\n');
         Err(output)
     }
+}
+
+pub fn system_time_to_string(system_time: SystemTime) -> String {
+    let timestamp = system_time.duration_since(UNIX_EPOCH).expect("can't get duration since unix epoch");
+    NaiveDateTime::from_timestamp(timestamp.as_secs() as i64, 0).to_string()
 }
 
 pub fn to_human_readable_string(size: u64) -> String {


### PR DESCRIPTION
fix some rustfmt issues in file ls.rst
fix fail when symlink is broken (will print info now)
add showing symbolic link destination (-l)
add possibilities to show date of:
* modification [--modified-date] (-l)
* access [--accessed-date]
* creation [--created-date]