### PR TITLE
Add ln command to coreutils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,10 @@ name = "kill"
 path = "src/bin/kill.rs"
 
 [[bin]]
+name = "ln"
+path = "src/bin/ln.rs"
+
+[[bin]]
 name = "ls"
 path = "src/bin/ls.rs"
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repository contains the core UNIX utilities for Redox OS. These are based o
 - `free`
 - `head`
 - `kill`
+- `ln`
 - `ls`
 - `mkdir`
 - `mv`

--- a/src/bin/ln.rs
+++ b/src/bin/ln.rs
@@ -1,0 +1,76 @@
+#![deny(warnings)]
+
+extern crate coreutils;
+extern crate extra;
+
+use std::env;
+use std::path::Path;
+use std::io::{stdout, stderr, Write};
+use std::fs::{remove_dir_all, hard_link};
+use std::os::unix::fs::symlink;
+use std::process::exit;
+
+use coreutils::ArgParser;
+use extra::option::OptionalExt;
+use extra::io::fail;
+
+const MAN_PAGE: &'static str = r#"
+NAME
+    ln - make links between files
+
+SYNOPSIS
+    ln [OPTIONS] TARGET LINK_NAME
+    ln [OPTIONS] TARGET
+
+DESCRIPTION
+    Create links between files.
+
+OPTIONS
+    -f --force
+        Force removing existing destination fila
+    -s --symbolic
+        Make symbolic link instead of hard link
+    --help
+        show this help and exit
+"#; /* @MANEND */
+
+
+fn main() {
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
+
+    let mut parser = ArgParser::new(6)
+        .add_flag(&["f", "force"])
+        .add_flag(&["s", "symbolic"])
+        .add_flag(&["", "help"]);
+    parser.parse(env::args());
+
+    if parser.found("help") || parser.args.len() == 0 {
+        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+        stdout.flush().try(&mut stderr);
+        exit(0);
+    } else {
+
+        let mut cwd = env::current_dir().expect("can't get cwd");
+        let src = Path::new(&parser.args[0]);
+        let dst = match parser.args.len() {
+            2 => Path::new(&parser.args[1]),
+            1 => {
+                cwd.push(src.file_name().try(&mut stderr));
+                cwd.as_path()
+            }
+            _ => fail("use --help", &mut stderr),
+        };
+
+        if parser.found("force") {
+            remove_dir_all(dst).try(&mut stderr);
+        }
+        if parser.found("symbolic") {
+            symlink(src, dst).try(&mut stderr);
+        } else {
+            hard_link(src, dst).try(&mut stderr);
+        }
+    }
+
+}


### PR DESCRIPTION
add basic ln command to the coreutils
ln supports symbolic links, hard links and force params

modification of mk (mk/userspace/coreutils.mk) in separate PR directly to redox repo