### PR TITLE
Add -f and -F to tail

### DIFF
--- a/src/bin/tail.rs
+++ b/src/bin/tail.rs
@@ -6,10 +6,12 @@ extern crate extra;
 use std::collections::VecDeque;
 use std::env;
 use std::fs;
+use std::time::Duration;
 use std::io::{self, BufRead, Read, Write};
+use std::io::{Seek, SeekFrom};
 use coreutils::ArgParser;
 use extra::option::OptionalExt;
-use extra::io::{WriteExt, fail};
+use extra::io::fail;
 
 static MAN_PAGE: &'static str = /* @MANSTART{tail} */ r#"
 NAME
@@ -44,28 +46,56 @@ OPTIONS
     --bytes +BYTES
         Print all but the first BYTES bytes.
 
+    -f
+        Follow the files content, that is, continue to read the given files
+        and print any change that occurs.
+
+    -s
+    --sleep-interval SECONDS
+        With -f, read at intervals of SECONDS seconds (defaults to 1.0).
+
 AUTHOR
     Written by Žad Deljkić.
 "#; /* @MANEND */
+
+#[derive(Debug)]
+pub struct LinesWithEnding<B> {
+    buf: B,
+}
+
+impl<B: BufRead> Iterator for LinesWithEnding<B> {
+    type Item = io::Result<String>;
+
+    fn next(&mut self) -> Option<io::Result<String>> {
+        let mut buf = String::new();
+        match self.buf.read_line(&mut buf) {
+            Ok(0) => None,
+            Ok(_) => Some(Ok(buf)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+fn lines_with_ending<B: BufRead>(reader: B) -> LinesWithEnding<B> where B: Sized {
+    LinesWithEnding { buf: reader }
+}
+
 
 fn tail<R: Read, W: Write>(input: R, output: W, lines: bool, skip: bool, num: usize) -> io::Result<()> {
     let mut writer = io::BufWriter::new(output);
 
     if lines {
         if skip {
-            let lines = io::BufReader::new(input).lines().skip(num);
+            let lines = lines_with_ending(io::BufReader::new(input)).skip(num);
 
             for line_res in lines {
                 match line_res {
-                    Ok(mut line) => {
-                        line.push('\n');
-                        try!(writer.write_all(line.as_bytes()));
-                    }
+                    Ok(line) => writer.write_all(line.as_bytes())?,
                     Err(err) => return Err(err),
                 };
             }
         } else {
-            let lines = io::BufReader::new(input).lines();
+            let lines = lines_with_ending(io::BufReader::new(input));
             let mut deque = VecDeque::new();
 
             for line_res in lines {
@@ -81,8 +111,7 @@ fn tail<R: Read, W: Write>(input: R, output: W, lines: bool, skip: bool, num: us
                 };
             }
 
-            for mut line in deque {
-                line.push('\n');
+            for line in deque {
                 try!(writer.write_all(line.as_bytes()));
             }
         }
@@ -122,14 +151,79 @@ fn tail<R: Read, W: Write>(input: R, output: W, lines: bool, skip: bool, num: us
     Ok(())
 }
 
+fn follow<R, W>(inputs: Vec<(&str, R)>, output: W, sleep_interval: Duration) -> io::Result<()>
+    where R: Read + Seek, W: Write
+{
+    if inputs.is_empty() {
+        return Ok(());
+    }
+
+    let stderr = io::stderr();
+    let mut stderr = stderr.lock();
+
+    let mut writer = io::BufWriter::new(output);
+
+    let mut last_updated_filename = inputs.last().unwrap().0;
+
+    let mut readers = Vec::new();
+    for (filename, input) in inputs {
+        let mut reader = io::BufReader::new(input);
+        let input_end = reader.seek(SeekFrom::End(0))?;
+        readers.push((filename, reader, input_end));
+    }
+
+    let mut buf = Vec::new();
+
+    loop {
+        std::thread::sleep(sleep_interval);
+
+        for &mut (filename, ref mut reader, ref mut last_input_end) in readers.iter_mut() {
+            let input_end = reader.seek(SeekFrom::End(0))?;
+
+            if input_end != *last_input_end {
+                if filename != last_updated_filename {
+                    writer.write_all(b"\n")?;
+                    print_filename_header(filename, &mut writer)?;
+                    last_updated_filename = filename;
+                }
+
+                if input_end < *last_input_end {
+                    stderr.write_all("tail: file ".as_bytes())?;
+                    stderr.write_all(filename.as_bytes())?;
+                    stderr.write_all(" truncated\n".as_bytes())?;
+
+                    reader.seek(SeekFrom::Start(0))?;
+                } else {
+                    reader.seek(SeekFrom::Start(*last_input_end))?;
+                }
+                buf.clear();
+                reader.read_to_end(&mut buf)?;
+                writer.write_all(&buf[..])?;
+                writer.flush()?;
+
+                *last_input_end = input_end;
+            }
+        }
+    }
+}
+
+fn print_filename_header<W: Write>(name: &str, output: &mut W) -> io::Result<()> {
+    output.write_all(b"==> ")?;
+    output.write_all(name.as_bytes())?;
+    output.write_all(b" <==\n")?;
+    Ok(())
+}
+
 fn main() {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
     let mut stderr = io::stderr();
-    let mut parser = ArgParser::new(3)
+    let mut parser = ArgParser::new(5)
         .add_opt_default("n", "lines", "10")
         .add_opt("c", "bytes")
-        .add_flag(&["h", "help"]);
+        .add_flag(&["h", "help"])
+        .add_flag(&["f"])
+        .add_opt_default("s", "sleep-interval", "1.0");
     parser.parse(env::args());
 
     if parser.found("help") {
@@ -156,21 +250,55 @@ fn main() {
             fail("missing argument (number of lines/bytes)", &mut stderr);
         };
 
+    let sleep_interval = {
+        let secs_str = parser.get_opt("sleep-interval").unwrap();
+        let secs = match secs_str.parse::<f32>() {
+            Ok(secs) if secs > 0.0 => secs,
+            _ => {
+                let msg = format!("invalid number of seconds '{}'", secs_str);
+                fail(&msg, &mut stderr);
+            },
+        };
+        let millis = (secs * 1000.0) as u64;
+        Duration::from_millis(millis)
+    };
+
     // run the main part
-    if parser.args.is_empty() {
+    let file_count = parser.args.len();
+
+    if file_count == 0 {
         let stdin = io::stdin();
-        let stdin = stdin.lock();
-        tail(stdin, stdout, lines, skip, num).try(&mut stderr);
-    } else if parser.args.len() == 1 {
-        let file = fs::File::open(&parser.args[0]).try(&mut stderr);
-        tail(file, stdout, lines, skip, num).try(&mut stderr);
+        let mut stdin = stdin.lock();
+
+        tail(&mut stdin, &mut stdout, lines, skip, num).try(&mut stderr);
+
+        if parser.found(&'f') {
+            let mut buf = String::new();
+            loop {
+                buf.clear();
+                stdin.read_line(&mut buf).try(&mut stderr);
+                stdout.write_all(buf.as_bytes()).try(&mut stderr);
+            }
+        }
     } else {
-        for path in &parser.args {
-            let file = fs::File::open(&path).try(&mut stderr);
-            stdout.write(b"==> ").try(&mut stderr);
-            stdout.write(path.as_bytes()).try(&mut stderr);
-            stdout.writeln(b" <==").try(&mut stderr);
+        let files = parser.args.iter()
+            .map(|filename| (filename.as_str(), fs::File::open(filename).try(&mut stderr)))
+            .collect::<Vec<(_, _)>>();
+
+        let mut print_newline = false;
+        for &(filename, ref file) in &files {
+            if file_count > 1 {
+                if print_newline {
+                    stdout.write_all(b"\n").try(&mut stderr);
+                }
+                print_newline = true;
+                print_filename_header(filename, &mut stdout).try(&mut stderr);
+            }
             tail(file, &mut stdout, lines, skip, num).try(&mut stderr);
+        }
+
+        if parser.found(&'f') {
+            follow(files, &mut stdout, sleep_interval).try(&mut stderr);
         }
     }
 }


### PR DESCRIPTION
Adds -f and -F to tail, which allow following the content of a file. Also adds -s to configure how often the utility should check for changes in files.

Also fixed a 'bug' where a newline would be printed when the last line of a file did not end with a newline.

I'd love some feedback!

Note: following files works on Linux, but not on Redox; it seems the seek() function on Redox isn't fully implemented (it seemed like it always returned 0, instead of what it should).