### PR TITLE
Consider Unicode spaces when counting words

### DIFF
--- a/testing/multi_line_lang_file
+++ b/testing/multi_line_lang_file
@@ -1,0 +1,15 @@
+Hello, 世界.
+
+This is a file with
+several lines and some of them are
+
+empty or with trailing orfunny spaces. 
+
+Pangrams in different languages:
+Жълтата дюля беше щастлива, че пухът, който цъфна, замръзна като гьон.
+Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο
+いろはにほへとちりぬるを
+? דג סקרן שט בים מאוכזב ולפתע מצא לו חברה איך הקליטה
+Pijamalı hasta, yağız şoföre çabucak güvendi.
+
+🦀


### PR DESCRIPTION
In order to support the Unicode Derived Core Property `White_Space` when
counting words, this change iterates over chars instead of bytes.
Otherwise, for instance, if a file containing the Greek letter `ς`
(`U+03C2`) is being iterated over as bytes the second byte of that
letter will get recognized as `U+00A0 (NBSP)` and therefore `wc` will
return wrong count of words.

A test file with several lines, different kind of spaces, a lot of
Unicode symbols for different languages and of course an emoji is also
added to confirm a correct behavior, which might be useful for other
utils when it comes to testing correct Unicode support.