### PR TITLE
Added 'uptime' command.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,10 @@ name = "uniq"
 path = "src/bin/uniq.rs"
 
 [[bin]]
+name = "uptime"
+path = "src/bin/uptime.rs"
+
+[[bin]]
 name = "wc"
 path = "src/bin/wc.rs"
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This repository contains the core UNIX utilities for Redox OS. These are based o
 - `tr`
 - `true`
 - `uniq`
+- `uptime`
 - `wc`
 - `which`
 - `yes`

--- a/src/bin/uptime.rs
+++ b/src/bin/uptime.rs
@@ -1,0 +1,80 @@
+#![deny(warnings)]
+
+extern crate coreutils;
+extern crate extra;
+extern crate syscall;
+
+use std::io::{self, Write};
+use std::process::exit;
+use coreutils::ArgParser;
+use extra::option::OptionalExt;
+use std::fmt::Write as FmtWrite;
+use std::env;
+
+const MAN_PAGE: &'static str = /* @MANSTART{date} */ r#"
+NAME
+    uptime - show how long the system has been running
+
+SYNOPSIS
+    uptime [ -h | --help] [offset]
+
+DESCRIPTION
+    Prints the length of time the system has been up.
+
+OPTIONS
+    -h
+    --help
+        display this help and exit
+"#; /* @MANEND */
+
+const SECONDS_PER_MINUTE: i64 = 60;
+const SECONDS_PER_HOUR: i64 = 3600;
+const SECONDS_PER_DAY: i64 = 86400;
+
+fn main() {
+   let stdout = io::stdout();
+   let mut stdout = stdout.lock();
+   let mut stderr = io::stderr();
+
+   let mut parser = ArgParser::new(1)
+        .add_flag(&["h", "help"]);
+   parser.parse(env::args());
+
+    if parser.found("help") {
+        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
+        stdout.flush().try(&mut stderr);
+        exit(0);
+    }
+
+    let mut uptime_str = String::new();
+
+    let mut ts = syscall::TimeSpec::default();
+    if syscall::clock_gettime(syscall::CLOCK_MONOTONIC, &mut ts).is_ok() {
+        let uptime = ts.tv_sec;
+        let uptime_secs = uptime % 60;
+        let uptime_mins = (uptime / SECONDS_PER_MINUTE) % 60;
+        let uptime_hours = (uptime / SECONDS_PER_HOUR) % 24;
+        let uptime_days = (uptime / SECONDS_PER_DAY) % 365;
+
+        let fmt_result;
+        if uptime_days > 0 {
+            fmt_result = write!(&mut uptime_str, "{}d {}h {}m {}s\n", uptime_days,
+                                uptime_hours, uptime_mins, uptime_secs);
+        } else if uptime_hours > 0 {
+            fmt_result = write!(&mut uptime_str, "{}h {}m {}s\n", uptime_hours,
+                                uptime_mins, uptime_secs);
+        } else if uptime_mins > 0 {
+            fmt_result = write!(&mut uptime_str, "{}m {}s\n", uptime_mins,
+                                uptime_secs);
+        } else {
+            fmt_result = write!(&mut uptime_str, "{}s\n", uptime_secs);
+        }
+
+        if fmt_result.is_err() {
+            println!("error: couldn't parse uptime");
+        }
+    }
+
+    stdout.write(uptime_str.as_bytes()).try(&mut stderr);
+    stdout.flush().try(&mut stderr);
+}


### PR DESCRIPTION
It only shows the uptime. Based on the `screenfetch` implementation.

Right now that code is duplicated but we could replace the code of `screenfetch` by interpolating the output of this one? Just an idea.

In the future we might add load average, user counts and all the other things the other `uptime` do.