### PR TITLE
Mainstream filetime can be used now.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 extra = { git = "https://github.com/redox-os/libextra.git" }
 termion = { git = "https://github.com/redox-os/termion.git" }
 userutils = { git = "https://github.com/redox-os/userutils.git" }
-filetime = { git = "https://github.com/ids1024/filetime.git", branch = "redox2" }
+filetime = { git = "https://github.com/alexcrichton/filetime.git" }
 redox_syscall = "0.1"
 walkdir = "1"
 time = "0.1"


### PR DESCRIPTION
I was trying to build Redox with latest coreutils and complains about @ids1024 fork not existing and I remembered that filetime Redox support just got merged.