### PR TITLE
Fix broken compilation on Redox.

### DIFF
--- a/src/bin/df.rs
+++ b/src/bin/df.rs
@@ -7,7 +7,7 @@ extern crate extra;
 extern crate syscall;
 
 #[cfg(target_os = "redox")]
-fn df(path: &str, parser: &ArgParser) -> ::std::io::Result<()> {
+fn df(path: &str, parser: &arg_parser::ArgParser) -> ::std::io::Result<()> {
     use coreutils::to_human_readable_string;
     use std::io::Error;
     use syscall::data::StatVfs;


### PR DESCRIPTION
This fixes build when cross-compiling which happened to be broken when I removed a unused import. 

Basically the CI compiles using the host compiler and not the Redox cross-compiled one.