### PR TITLE
Common arg_parser utility for coreutils

### DIFF
--- a/src/bin/base64.rs
+++ b/src/bin/base64.rs
@@ -3,13 +3,15 @@
 extern crate arg_parser;
 extern crate extra;
 extern crate base64;
+#[macro_use]
+extern crate coreutils;
 
 use std::io::{self, Write, Read, Stderr};
 use std::path::Path;
 use std::fs::File;
-use std::env;
 use std::process;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 use extra::io::fail;
 
@@ -57,31 +59,17 @@ AUTHOR
     Written by Jose Narvaez.
 "#; /* @MANEND */
 
-const HELP_INFO: &'static str = "Try ‘base64 --help’ for more information.\n";
 fn main() {
-    let stdout = io::stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = io::stderr();
-    let stdin = io::stdin();
-
     let mut parser = ArgParser::new(3)
         .add_flag(&["d", "decode"])
         .add_flag(&["e", "encode"])
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("base64"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        process::exit(0);
-    }
-
-    if let Err(err) = parser.found_invalid() {
-        stderr.write_all(err.as_bytes()).try(&mut stderr);
-        stdout.write_all(HELP_INFO.as_bytes()).try(&mut stderr);
-        stderr.flush().try(&mut stderr);
-        process::exit(1);
-    }
+    let stdout = io::stdout();
+    let stdout = stdout.lock();
+    let mut stderr = io::stderr();
+    let stdin = io::stdin();
 
     let mut input: Option<Box<Read>> = None;
     let mut output: Option<Box<Write>> = None;

--- a/src/bin/clear.rs
+++ b/src/bin/clear.rs
@@ -2,12 +2,12 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
-use std::io::{stdout, stderr, Write};
-use std::process::exit;
+use std::io::{stdout, Write};
 use arg_parser::ArgParser;
-use extra::option::OptionalExt;
+use coreutils::arg_parser::ArgParserExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{clear} */ r#"
 NAME
@@ -26,18 +26,11 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("clear"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
-
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
     let _ = stdout.write(b"\x1B[2J");
 }

--- a/src/bin/cp.rs
+++ b/src/bin/cp.rs
@@ -3,13 +3,14 @@
 extern crate arg_parser;
 extern crate extra;
 extern crate walkdir;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs;
-use std::io::{stderr, stdout, Write};
+use std::io::stderr;
 use std::path;
-use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::io::fail;
 use extra::option::OptionalExt;
 
@@ -43,22 +44,14 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["r", "recursive"])
         .add_flag(&["n", "no-action"])
         .add_flag(&["v", "verbose"])
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("cp"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
-
+    let mut stderr = stderr();
     let recurse = parser.found("recursive");
     let verbose = parser.found("verbose");
     let execute = !parser.found("no-action");

--- a/src/bin/cut.rs
+++ b/src/bin/cut.rs
@@ -2,8 +2,9 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fmt;
 use std::fs;
 use std::io::{self, BufRead, Read, Write};
@@ -11,6 +12,7 @@ use std::slice;
 use std::str::FromStr;
 
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 
 use extra::io::{fail, WriteExt};
 use extra::option::OptionalExt;
@@ -338,6 +340,15 @@ enum Mode {
 
 
 fn main() {
+    let mut parser = ArgParser::new(6)
+        .add_flag(&["h", "help"])
+        .add_flag(&["s"])
+        .add_opt("b", "")
+        .add_opt("c", "")
+        .add_opt("f", "")
+        .add_opt("d", "");
+    parser.process_common(help_info!("cut"), MAN_PAGE);
+
     // Arguments.
     let mut mode = None;
     let mut delimiter = None;
@@ -347,20 +358,6 @@ fn main() {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
     let mut stderr = io::stderr();
-
-    let mut parser = ArgParser::new(6)
-        .add_flag(&["h", "help"])
-        .add_flag(&["s"])
-        .add_opt("b", "")
-        .add_opt("c", "")
-        .add_opt("f", "")
-        .add_opt("d", "");
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        let _ = stdout.write(MAN_PAGE.as_bytes());
-        return;
-    }
 
     if parser.found(&'s') {
         skip_if_missing = Some(true);

--- a/src/bin/date.rs
+++ b/src/bin/date.rs
@@ -1,14 +1,14 @@
 #![deny(warnings)]
 
 extern crate arg_parser;
+#[macro_use]
 extern crate coreutils;
 extern crate extra;
 
-use std::env;
 use std::io::{stdout, stderr, Write};
-use std::process::exit;
 use std::time::{SystemTime, UNIX_EPOCH};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use coreutils::format_time;
 use extra::option::OptionalExt;
 
@@ -29,18 +29,13 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
+    let mut parser = ArgParser::new(1)
+        .add_flag(&["h", "help"]);
+    parser.process_common(help_info!("date"), MAN_PAGE);
+
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
-    let mut parser = ArgParser::new(1)
-        .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
 
     let mut tz_offset = 0;
     for arg in &parser.args {

--- a/src/bin/dd.rs
+++ b/src/bin/dd.rs
@@ -1,17 +1,16 @@
 #![deny(warnings)]
 
 extern crate arg_parser;
+#[macro_use]
 extern crate coreutils;
 extern crate extra;
 
-use std::env;
 use std::fs::File;
 use std::io::{self, stderr, stdin, stdout, Read, Write};
 use std::time::Instant;
-use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use coreutils::to_human_readable_string;
-use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{dd} */ r#"
 NAME
@@ -75,25 +74,19 @@ impl<'a> io::Write for Output<'a> {
 }
 
 fn main() {
-    let stdin = stdin();
-    let stdin = stdin.lock();
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
-
     let mut parser = ArgParser::new(5)
         .add_flag(&["h", "help"])
         .add_setting_default("bs", "512")
         .add_setting_default("count", "-1")
         .add_setting("if")
         .add_setting("of");
-    parser.parse(env::args());
+    parser.process_common(help_info!("dd"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let stdin = stdin();
+    let stdin = stdin.lock();
+    let stdout = stdout();
+    let stdout = stdout.lock();
+    let mut stderr = stderr();
 
     let bs: usize = parser.get_setting("bs").unwrap().parse::<usize>().unwrap();
     let count = parser.get_setting("count").unwrap().parse::<i32>().unwrap();

--- a/src/bin/df.rs
+++ b/src/bin/df.rs
@@ -50,6 +50,8 @@ fn main() {
     use std::io::{stdout, stderr, BufRead, BufReader, Write};
     use std::process::exit;
     use arg_parser::ArgParser;
+    #[macro_use]
+    use coreutils::arg_parser::ArgParserExt;
     use extra::option::OptionalExt;
 
     const MAN_PAGE: &'static str = /* @MANSTART{df} */ r#"
@@ -70,19 +72,14 @@ fn main() {
             display this help and exit
     "#; /* @MANEND */
 
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "human-readable"])
         .add_flag(&["help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("df"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
 
     println!("{:<10}{:>10}{:>10}{:>10}{:>5}", "Path", "Size", "Used", "Free", "Use%");
     if parser.args.is_empty() {

--- a/src/bin/dirname.rs
+++ b/src/bin/dirname.rs
@@ -2,11 +2,11 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
-use std::io::{stdout, stderr, Write};
 use arg_parser::ArgParser;
-use extra::option::OptionalExt;
+use coreutils::arg_parser::ArgParserExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{dirname} */ r#"
 NAME
@@ -24,18 +24,9 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
+    parser.process_common(help_info!("dirname"), MAN_PAGE);
 
     for path in &parser.args[0..] {
         if path.len() != 0 && path.chars().all(|c| c == '/') {

--- a/src/bin/du.rs
+++ b/src/bin/du.rs
@@ -1,15 +1,15 @@
 #![deny(warnings)]
 
 extern crate arg_parser;
+#[macro_use]
 extern crate coreutils;
 extern crate extra;
 
-use std::env;
 use std::fs;
 use std::path::Path;
 use std::io::{stdout, stderr, StdoutLock, Stderr, Write};
-use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use coreutils::to_human_readable_string;
 use extra::option::OptionalExt;
 
@@ -80,19 +80,14 @@ fn list_dir(path: &str, parser: &ArgParser, stdout: &mut StdoutLock, stderr: &mu
 }
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(2)
         .add_flag(&["h", "human-readable"])
         .add_flag(&["help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("du"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
 
     if parser.args.is_empty() {
         list_dir(".", &parser, &mut stdout, &mut stderr);

--- a/src/bin/echo.rs
+++ b/src/bin/echo.rs
@@ -2,11 +2,13 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::io::{stdout, stderr, Write};
 use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{echo} */ r#"
@@ -44,21 +46,16 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(4)
         .add_flag(&["e", "escape"])
         .add_flag(&["n", "no-newline"])
         .add_flag(&["s", "no-spaces"])
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("echo"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
 
     // Print to standard output
     let mut first = true;

--- a/src/bin/false.rs
+++ b/src/bin/false.rs
@@ -1,11 +1,13 @@
 #![deny(warnings)]
 
 extern crate arg_parser;
+#[macro_use]
+extern crate coreutils;
 
 use std::process;
 use std::env;
-use std::io::{self, Write};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::{print_man_page, print_help};
 
 const MAN_PAGE: &'static str = /* @MANSTART{false} */ r#"NAME
     false - do nothing, unsuccessfully
@@ -19,13 +21,13 @@ DESCRIPTION
 
 fn main() {
     if env::args().len() > 1 {
-        let stdout = io::stdout();
-        let mut stdout = stdout.lock();
         let mut parser = ArgParser::new(1).add_flag(&["h", "help"]);
         parser.parse(env::args());
-        if parser.found("help") {
-            stdout.write(MAN_PAGE.as_bytes()).ok();
-            stdout.flush().ok();
+        if let Err(err) = parser.found_invalid() {
+            print_help(&err, help_info!("false"));
+        }
+        else if parser.found("help") {
+            print_man_page(MAN_PAGE);
         }
     }
     process::exit(1);

--- a/src/bin/free.rs
+++ b/src/bin/free.rs
@@ -42,10 +42,11 @@ fn free(parser: &arg_parser::ArgParser) -> ::std::io::Result<()> {
 
 #[cfg(target_os = "redox")]
 fn main() {
-    use std::env;
     use std::io::{stdout, stderr, Write};
     use std::process::exit;
     use arg_parser::ArgParser;
+    #[macro_use]
+    use coreutils::arg_parser::ArgParserExt;
     use extra::option::OptionalExt;
 
     const MAN_PAGE: &'static str = /* @MANSTART{free} */ r#"
@@ -72,13 +73,7 @@ fn main() {
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "human-readable"])
         .add_flag(&["help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    parser.process_common(help_info!("free"), MAN_PAGE);
 
     println!("{:<8}{:>10}{:>10}{:>10}", "", "total", "used", "free");
     free(&parser).try(&mut stderr);

--- a/src/bin/head.rs
+++ b/src/bin/head.rs
@@ -2,11 +2,13 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs;
 use std::io::{self, BufRead, Read, Write};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::io::{fail, WriteExt};
 use extra::option::OptionalExt;
 
@@ -69,28 +71,19 @@ fn head<R: Read, W: Write>(input: R, output: W, lines: bool, num: usize) -> io::
 }
 
 fn main() {
-    let stdout = io::stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = io::stderr();
     let mut parser = ArgParser::new(3)
         .add_opt_default("n", "lines", "10")
         .add_opt("c", "bytes")
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("head"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = io::stderr();
+
     if parser.found(&'c') || parser.found("bytes") {
         parser.opt(&'n').clear();
         parser.opt("lines").clear();
-    }
-    if let Err(err) = parser.found_invalid() {
-        stderr.write_all(err.as_bytes()).try(&mut stderr);
-        stderr.flush().try(&mut stderr);
-        return;
     }
 
     let (lines, num): (bool, usize) =

--- a/src/bin/kill.rs
+++ b/src/bin/kill.rs
@@ -4,6 +4,7 @@ extern crate arg_parser;
 extern crate extra;
 #[cfg(target_os = "redox")]
 extern crate syscall;
+extern crate coreutils;
 
 #[cfg(target_os = "redox")]
 fn main() {
@@ -12,6 +13,8 @@ fn main() {
     use arg_parser::ArgParser;
     use extra::io::fail;
     use extra::option::OptionalExt;
+    #[macro_use]
+    use coreutils;
 
     const MAN_PAGE: &'static str = /* @MANSTART{kill} */ r#"
     NAME
@@ -28,18 +31,13 @@ fn main() {
             print this message
     "#; /* @MANEND */
 
+    let mut parser = ArgParser::new(1)
+        .add_flag(&["h", "help"]);
+    parser.process_common(help_info!("kill"), MAN_PAGE);
+
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
-    let mut parser = ArgParser::new(1)
-        .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
 
     if let Some(sig_arg) = parser.args.get(0) {
         let sig = sig_arg.parse::<usize>().try(&mut stderr);

--- a/src/bin/ln.rs
+++ b/src/bin/ln.rs
@@ -2,15 +2,17 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
 use std::env;
 use std::path::Path;
-use std::io::{stdout, stderr, Write};
+use std::io::stderr;
 use std::fs::{remove_dir_all, hard_link};
 use std::os::unix::fs::symlink;
-use std::process::exit;
 
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 use extra::io::fail;
 
@@ -36,47 +38,38 @@ OPTIONS
 
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
-
     let mut parser = ArgParser::new(6)
         .add_flag(&["f", "force"])
         .add_flag(&["s", "symbolic"])
         .add_flag(&["", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("ln"), MAN_PAGE);
 
-    if parser.found("help") || parser.args.len() == 0 {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
+    let mut stderr = stderr();
+
+    let mut cwd = env::current_dir().expect("can't get cwd");
+    let src = Path::new(&parser.args[0]);
+    let dst = match parser.args.len() {
+        2 => Path::new(&parser.args[1]),
+        1 => {
+            cwd.push(src.file_name().try(&mut stderr));
+            cwd.as_path()
+        }
+        _ => fail("use --help", &mut stderr),
+    };
+
+    let mut dst = dst.to_owned();
+    if dst.is_dir() {
+        dst.push(src.file_name().unwrap_or(src.as_os_str()));
+    }
+
+    if parser.found("force") {
+        remove_dir_all(&dst).try(&mut stderr);
+    }
+
+    if parser.found("symbolic") {
+        symlink(src, &dst).try(&mut stderr);
     } else {
-
-        let mut cwd = env::current_dir().expect("can't get cwd");
-        let src = Path::new(&parser.args[0]);
-        let dst = match parser.args.len() {
-            2 => Path::new(&parser.args[1]),
-            1 => {
-                cwd.push(src.file_name().try(&mut stderr));
-                cwd.as_path()
-            }
-            _ => fail("use --help", &mut stderr),
-        };
-
-        let mut dst = dst.to_owned();
-        if dst.is_dir() {
-            dst.push(src.file_name().unwrap_or(src.as_os_str()));
-        }
-
-        if parser.found("force") {
-            remove_dir_all(&dst).try(&mut stderr);
-        }
-
-        if parser.found("symbolic") {
-            symlink(src, &dst).try(&mut stderr);
-        } else {
-            hard_link(src, &dst).try(&mut stderr);
-        }
+        hard_link(src, &dst).try(&mut stderr);
     }
 
 }

--- a/src/bin/mkdir.rs
+++ b/src/bin/mkdir.rs
@@ -2,13 +2,13 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs;
-use std::io::{stdout, stderr, Write};
-use std::process::exit;
+use std::io::stderr;
 use arg_parser::ArgParser;
-use extra::io::fail;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{mkdir} */ r#"
@@ -29,22 +29,13 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(2)
         .add_flag(&["h", "help"])
         .add_flag(&["p", "parents"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("mkdir"), MAN_PAGE);
+    parser.process_no_argument();
 
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
-    if parser.args.is_empty() {
-        fail("No arguments. Use --help to see the usage.", &mut stderr);
-    }
+    let mut stderr = stderr();
 
     let mut parents = false;
     if parser.found("parents") {

--- a/src/bin/mv.rs
+++ b/src/bin/mv.rs
@@ -3,13 +3,14 @@
 extern crate arg_parser;
 extern crate extra;
 extern crate walkdir;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs;
-use std::io::{stderr, stdout, Write};
+use std::io::stderr;
 use std::path;
-use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::io::fail;
 use extra::option::OptionalExt;
 use walkdir::WalkDir;
@@ -31,21 +32,14 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["r", "recursive"])
         .add_flag(&["n", "no-action"])
         .add_flag(&["v", "verbose"])
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("mv"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let mut stderr = stderr();
 
     let recurse = parser.found("recursive");
     let verbose = parser.found("verbose");

--- a/src/bin/printenv.rs
+++ b/src/bin/printenv.rs
@@ -2,11 +2,14 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
 use std::env;
 use std::io::{stdout, stderr, Write};
 use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::io::WriteExt;
 use extra::option::OptionalExt;
 
@@ -32,13 +35,7 @@ fn main() {
     let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    parser.process_common(help_info!("printenv"), MAN_PAGE);
 
     if parser.args.is_empty() {
         stderr.write(b"Please provide a variable name\n").try(&mut stderr);

--- a/src/bin/ps.rs
+++ b/src/bin/ps.rs
@@ -2,12 +2,13 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs::File;
-use std::io::{stdout, stderr, copy, Write};
-use std::process::exit;
+use std::io::{stdout, stderr, copy};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{ps} */ r#"
@@ -27,18 +28,13 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
+    let mut parser = ArgParser::new(1)
+        .add_flag(&["h", "help"]);
+    parser.process_common(help_info!("ps"), MAN_PAGE);
+
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
-    let mut parser = ArgParser::new(1)
-        .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
 
     let mut file = File::open("sys:/context").try(&mut stderr);
     copy(&mut file, &mut stdout).try(&mut stderr);

--- a/src/bin/pwd.rs
+++ b/src/bin/pwd.rs
@@ -2,10 +2,13 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
 use std::env;
 use std::io::{stdout, stderr, Write};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{pwd} */ r#"
@@ -30,13 +33,7 @@ fn main() {
     let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
+    parser.process_common(help_info!("pwd"), MAN_PAGE);
 
     let pwd = env::current_dir().try(&mut stderr);
 

--- a/src/bin/readlink.rs
+++ b/src/bin/readlink.rs
@@ -2,12 +2,12 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs;
-use std::io::{stdout, stderr, Write};
 use arg_parser::ArgParser;
-use extra::option::OptionalExt;
+use coreutils::arg_parser::ArgParserExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{readlink} */ r#"
 NAME
@@ -25,18 +25,9 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
+    parser.process_common(help_info!("readlink"), MAN_PAGE);
 
     for path in &parser.args[0..] {
         println!("{}", fs::read_link(path).unwrap().display());

--- a/src/bin/realpath.rs
+++ b/src/bin/realpath.rs
@@ -2,13 +2,14 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs;
-use std::io::{stdout, stderr, Write};
-use std::process::exit;
+use std::io::{stdout, stderr};
 use arg_parser::ArgParser;
-use extra::io::{fail, WriteExt};
+use coreutils::arg_parser::ArgParserExt;
+use extra::io::{WriteExt};
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{realpath} */ r#"
@@ -33,17 +34,8 @@ fn main() {
     let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
-
-    if parser.args.is_empty() {
-        fail("No arguments. Use --help to see the usage.", &mut stderr);
-    }
+    parser.process_common(help_info!("realpath"), MAN_PAGE);
+    parser.process_no_argument();
 
     for path in &parser.args {
         let file = fs::canonicalize(path).try(&mut stderr);

--- a/src/bin/reset.rs
+++ b/src/bin/reset.rs
@@ -2,12 +2,12 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
-use std::io::{stdout, stderr, Write};
-use std::process::exit;
+use std::io::{stdout, Write};
 use arg_parser::ArgParser;
-use extra::option::OptionalExt;
+use coreutils::arg_parser::ArgParserExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{reset} */ r#"
 NAME
@@ -26,18 +26,11 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("reset"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
-
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
     let _ = stdout.write(b"\x1Bc");
 }

--- a/src/bin/rmdir.rs
+++ b/src/bin/rmdir.rs
@@ -2,12 +2,13 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs;
-use std::io::{stdout, stderr, Write};
+use std::io::stderr;
 use arg_parser::ArgParser;
-use extra::io::fail;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{rmdir} */ r#"
@@ -26,22 +27,12 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("rmdir"), MAN_PAGE);
+    parser.process_no_argument();
 
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
-
-    if parser.args.is_empty() {
-        fail("No arguments. Use --help to see the usage.", &mut stderr);
-    }
+    let mut stderr = stderr();
 
     for path in &parser.args {
         fs::remove_dir(path).try(&mut stderr);

--- a/src/bin/seq.rs
+++ b/src/bin/seq.rs
@@ -2,10 +2,12 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
-use std::io::{stdout, stderr, Write};
+use std::io::{stdout, stderr};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 use extra::io::{fail, WriteExt};
 
@@ -27,18 +29,13 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
+    let mut parser = ArgParser::new(1)
+        .add_flag(&["h", "help"]);
+    parser.process_common(help_info!("seq"), MAN_PAGE);
+
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
-    let mut parser = ArgParser::new(1)
-        .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
 
     if parser.args.is_empty() {
         fail("missing value.", &mut stderr);

--- a/src/bin/shutdown.rs
+++ b/src/bin/shutdown.rs
@@ -3,11 +3,12 @@
 extern crate arg_parser;
 extern crate extra;
 extern crate syscall;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
-use std::io::{stderr, stdout, Error, Write};
-use std::process::exit;
+use std::io::{stderr, Error};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 use syscall::flag::{SIGTERM, SIGKILL};
 
@@ -32,19 +33,12 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"])
         .add_flag(&["r", "reboot"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("shutdown"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let mut stderr = stderr();
 
     if parser.found("reboot") {
         syscall::kill(1, SIGTERM).map_err(|err| Error::from_raw_os_error(err.errno)).try(&mut stderr);

--- a/src/bin/sleep.rs
+++ b/src/bin/sleep.rs
@@ -2,13 +2,15 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::io::{self, Write, Stderr};
 use std::process::exit;
 use std::thread;
 use std::time::Duration;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::{ArgParserExt, print_help};
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{sleep} */ r#"
@@ -39,21 +41,13 @@ AUTHOR
 "#; /* @MANEND */
 
 const MISSING_OPERAND: &'static str = "missing operand\n";
-const HELP_INFO:       &'static str = "Try 'sleep --help' for more information.\n";
 
 fn main() {
-    let stdout     = io::stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = io::stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("sleep"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let mut stderr = io::stderr();
 
     if !parser.args.is_empty() {
         let sleep_times_in_ms = parser.args.iter()
@@ -65,9 +59,7 @@ fn main() {
         }
 
     } else {
-        stderr.write(MISSING_OPERAND.as_bytes()).try(&mut stderr);
-        stderr.write(HELP_INFO.as_bytes()).try(&mut stderr);
-        stderr.flush().try(&mut stderr);
+        print_help(MISSING_OPERAND, help_info!("sleep"));
         exit(1);
     }
 }

--- a/src/bin/sort.rs
+++ b/src/bin/sort.rs
@@ -2,14 +2,14 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
-use std::io::{stdout, stderr, stdin, Error, Write, BufRead, BufReader};
-use std::process::exit;
+use std::io::{stderr, stdin, Error, Write, BufRead, BufReader};
 use std::cmp::Ordering;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use std::fs::File;
-use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = r#"
 NAME
@@ -86,21 +86,13 @@ fn lines_from_files(paths: &Vec<&String>) -> Result<Vec<String>, Error> {
 }
 
 fn main() {
-
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(2)
         .add_flag(&["n", "numeric-sort"])
         .add_flag(&["u", "unique"])
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("sort"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let mut stderr = stderr();
 
     let lines = match parser.args.is_empty() {
         true => lines_from_stdin(),

--- a/src/bin/stat.rs
+++ b/src/bin/stat.rs
@@ -4,13 +4,15 @@ extern crate arg_parser;
 extern crate extra;
 extern crate time;
 extern crate userutils;
+#[macro_use]
+extern crate coreutils;
 
-use std::{env, fmt, fs};
+use std::{fmt, fs};
 use std::fs::File;
-use std::io::{stdout, stderr, Read, Write};
+use std::io::Read;
 use std::vec::Vec;
 use arg_parser::ArgParser;
-use extra::option::OptionalExt;
+use coreutils::arg_parser::ArgParserExt;
 use userutils::{Passwd, Group};
 use std::os::unix::fs::MetadataExt;
 use time::Timespec;
@@ -71,18 +73,9 @@ fn lookup_group<'a>(group: &'a [Group], gid: u32) -> &'a str {
 }
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
+    parser.process_common(help_info!("stat"), MAN_PAGE);
 
     let mut passwd_string = String::new();
     File::open("/etc/passwd").unwrap().read_to_string(&mut passwd_string).unwrap();

--- a/src/bin/tail.rs
+++ b/src/bin/tail.rs
@@ -2,9 +2,10 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
 use std::collections::VecDeque;
-use std::env;
 use std::fs::File;
 use std::os::unix::fs::MetadataExt;
 use std::time::Duration;
@@ -12,6 +13,7 @@ use std::io::{self, BufRead, Read, Write};
 use std::io::{Seek, SeekFrom};
 use std::error::Error;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 use extra::io::fail;
 
@@ -265,23 +267,12 @@ fn main() {
         .add_flag(&["f"])
         .add_flag(&["F"])
         .add_opt_default("s", "sleep-interval", "1.0");
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
+    parser.process_common(help_info!("tail"), MAN_PAGE);
     if parser.found(&'c') || parser.found("bytes") {
         parser.opt("lines").clear();
     }
     if parser.found(&'F') {
         *parser.flag(&'f') = true;
-    }
-    if let Err(err) = parser.found_invalid() {
-        stderr.write_all(err.as_bytes()).try(&mut stderr);
-        stderr.flush().try(&mut stderr);
-        return;
     }
     let (lines, skip, num): (bool, bool, usize) =
         if let Some(num) = parser.get_opt("lines") {

--- a/src/bin/tee.rs
+++ b/src/bin/tee.rs
@@ -1,8 +1,11 @@
 //#![deny(warnings)]
 
 extern crate arg_parser;
+#[macro_use]
+extern crate coreutils;
 
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use std::{process, env};
 use std::io::{self, Read, Write};
 
@@ -29,16 +32,9 @@ fn main() {
     let mut parser = ArgParser::new(2).
         add_flag(&["a", "append"]).
         add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("tee"), MAN_PAGE);
 
     let mut stdout = io::stdout();
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).unwrap();
-        stdout.flush().unwrap();
-        process::exit(0);
-    }
-
     let mut fds: Vec<std::fs::File> = Vec::with_capacity(env::args().len());
 
     if parser.found("append") {

--- a/src/bin/time.rs
+++ b/src/bin/time.rs
@@ -2,12 +2,14 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::io::{stdout, stderr, Write};
-use std::process::{exit, Command};
+use std::process::Command;
 use std::time::Instant;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{time} */ r#"
@@ -32,13 +34,7 @@ fn main() {
     let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    parser.process_common(help_info!("time"), MAN_PAGE);
 
     let time = Instant::now();
 

--- a/src/bin/touch.rs
+++ b/src/bin/touch.rs
@@ -3,16 +3,17 @@
 extern crate arg_parser;
 extern crate extra;
 extern crate filetime;
+#[macro_use]
+extern crate coreutils;
 
 use std::env;
 use std::fs::File;
-use std::io::{stdout, stderr, Write};
+use std::io::stderr;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::path::Path;
-use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
-use extra::io::fail;
 use filetime::{set_file_times, FileTime};
 
 const MAN_PAGE: &'static str = /* @MANSTART{touch} */ r#"
@@ -32,32 +33,21 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
+    parser.process_common(help_info!("touch"), MAN_PAGE);
+    parser.process_no_argument();
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let mut stderr = stderr();
 
-    if parser.args.is_empty() {
-        fail("no arguments.", &mut stderr);
-    }
-    else {
-        // TODO update file modification date/time
-        for arg in env::args().skip(1) {
-            if Path::new(&arg).is_file() {
-                let mtime = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-                let time = FileTime::from_seconds_since_1970(mtime.as_secs(), mtime.subsec_nanos());
-                set_file_times(&arg, time, time).try(&mut stderr);
-            } else {
-                File::create(&arg).try(&mut stderr);
-            }
+    // TODO update file modification date/time
+    for arg in env::args().skip(1) {
+        if Path::new(&arg).is_file() {
+            let mtime = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+            let time = FileTime::from_seconds_since_1970(mtime.as_secs(), mtime.subsec_nanos());
+            set_file_times(&arg, time, time).try(&mut stderr);
+        } else {
+            File::create(&arg).try(&mut stderr);
         }
     }
 }

--- a/src/bin/true.rs
+++ b/src/bin/true.rs
@@ -1,11 +1,13 @@
 #![deny(warnings)]
 
 extern crate arg_parser;
+#[macro_use]
+extern crate coreutils;
 
 use std::process;
 use std::env;
-use std::io::{self, Write};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::{print_man_page, print_help};
 
 const MAN_PAGE: &'static str = /* @MANSTART{true} */ r#"NAME
     true - do nothing, successfully
@@ -19,13 +21,13 @@ DESCRIPTION
 
 fn main() {
     if env::args().len() > 1 {
-        let stdout = io::stdout();
-        let mut stdout = stdout.lock();
         let mut parser = ArgParser::new(1).add_flag(&["h", "help"]);
         parser.parse(env::args());
-        if parser.found("help") {
-            stdout.write(MAN_PAGE.as_bytes()).ok();
-            stdout.flush().ok();
+        if let Err(err) = parser.found_invalid() {
+            print_help(&err, help_info!("true"));
+        }
+        else if parser.found("help") {
+            print_man_page(MAN_PAGE);
         }
     }
     process::exit(0);

--- a/src/bin/uname.rs
+++ b/src/bin/uname.rs
@@ -2,15 +2,14 @@
 
 extern crate extra;
 extern crate arg_parser;
+#[macro_use]
+extern crate coreutils;
 
-use std::io::{self, Write};
-use std::env;
-use std::process;
+use std::io::Read;
 use std::fs::File;
 use std::string::String;
 use arg_parser::ArgParser;
-use extra::option::OptionalExt;
-use std::io::Read;
+use coreutils::arg_parser::ArgParserExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{uname} */ r#"
 NAME
@@ -47,9 +46,6 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = io::stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = io::stderr();
     let mut parser = ArgParser::new(7)
         .add_flag(&["a", "all"])
         .add_flag(&["m", "machine"])
@@ -58,13 +54,7 @@ fn main() {
         .add_flag(&["s", "kernel-name"])
         .add_flag(&["v", "kernel-version"])
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        process::exit(0);
-    }
+    parser.process_common(help_info!("uname"), MAN_PAGE);
 
     if parser.found("all") {
         *parser.flag("machine") = true;

--- a/src/bin/uptime.rs
+++ b/src/bin/uptime.rs
@@ -3,13 +3,14 @@
 extern crate arg_parser;
 extern crate extra;
 extern crate syscall;
+#[macro_use]
+extern crate coreutils;
 
 use std::io::{self, Write};
-use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 use std::fmt::Write as FmtWrite;
-use std::env;
 
 const MAN_PAGE: &'static str = /* @MANSTART{uptime} */ r#"
 NAME
@@ -32,19 +33,13 @@ const SECONDS_PER_HOUR: i64 = 3600;
 const SECONDS_PER_DAY: i64 = 86400;
 
 fn main() {
-   let stdout = io::stdout();
-   let mut stdout = stdout.lock();
-   let mut stderr = io::stderr();
-
-   let mut parser = ArgParser::new(1)
+    let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-   parser.parse(env::args());
+    parser.process_common(help_info!("uptime"), MAN_PAGE);
 
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = io::stderr();
 
     let mut uptime_str = String::new();
 

--- a/src/bin/wc.rs
+++ b/src/bin/wc.rs
@@ -3,13 +3,14 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
 use std::fs::File;
 use std::io::{self, stdout, stderr, Read, Write, Stderr};
 use std::ops::{Add, AddAssign};
-use std::process::exit;
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 use extra::io::WriteExt;
 
@@ -184,21 +185,12 @@ fn print_count<'a, W: Write>(parser: &ArgParser, count: Counter, path: &'a str, 
 }
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
-    let mut stderr = stderr();
     let mut parser = ArgParser::new(4)
         .add_flag(&["l", "lines"])
         .add_flag(&["w", "words"])
         .add_flag(&["c", "bytes"])
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.writeln(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    parser.process_common(help_info!("wc"), MAN_PAGE);
 
     if !(parser.found("lines") ||
          parser.found("words") ||
@@ -207,6 +199,10 @@ fn main() {
         *parser.flag("words") = true;
         *parser.flag("bytes") = true;
     }
+
+    let stdout = stdout();
+    let mut stdout = stdout.lock();
+    let mut stderr = stderr();
 
     if parser.args.is_empty() {
         let stdin = io::stdin();

--- a/src/bin/which.rs
+++ b/src/bin/which.rs
@@ -2,11 +2,14 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
 use std::env;
 use std::process::exit;
-use std::io::{stdout, stderr, Write};
+use std::io::{stderr, Write};
 use arg_parser::ArgParser;
+use coreutils::arg_parser::ArgParserExt;
 use extra::option::OptionalExt;
 
 const MAN_PAGE: &'static str = r#"
@@ -23,17 +26,9 @@ OPTIONS
 "#; /* @MANEND */
 
 fn main() {
-    let stdout = stdout();
-    let mut stdout = stdout.lock();
     let mut stderr = stderr();
     let mut parser = ArgParser::new(1).add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        exit(0);
-    }
+    parser.process_common(help_info!("which"), MAN_PAGE);
 
     if parser.args.is_empty() {
         stderr.write(b"Please provide a program name\n").try(&mut stderr);

--- a/src/bin/yes.rs
+++ b/src/bin/yes.rs
@@ -2,13 +2,14 @@
 
 extern crate arg_parser;
 extern crate extra;
+#[macro_use]
+extern crate coreutils;
 
-use std::env;
-use std::process;
-use std::io::{stdout, stderr, Write};
+use std::io::{stdout, stderr};
 use arg_parser::ArgParser;
 use extra::io::WriteExt;
 use extra::option::OptionalExt;
+use coreutils::arg_parser::ArgParserExt;
 
 const MAN_PAGE: &'static str = /* @MANSTART{yes} */ r#"
 NAME
@@ -27,28 +28,13 @@ OPTIONS
         Print this manual page.
 "#; /* @MANEND */
 
-const HELP_INFO:       &'static str = "Try ‘yes --help’ for more information.\n";
-
 fn main() {
     let stdout = stdout();
     let mut stdout = stdout.lock();
     let mut stderr = stderr();
     let mut parser = ArgParser::new(1)
         .add_flag(&["h", "help"]);
-    parser.parse(env::args());
-
-    if parser.found("help") {
-        stdout.write_all(MAN_PAGE.as_bytes()).try(&mut stderr);
-        stdout.flush().try(&mut stderr);
-        return;
-    }
-
-    if let Err(err) = parser.found_invalid() {
-        stderr.write_all(err.as_bytes()).try(&mut stderr);
-        stdout.write_all(HELP_INFO.as_bytes()).try(&mut stderr);
-        stderr.flush().try(&mut stderr);
-        process::exit(1);
-    }
+    parser.process_common(help_info!("yes"), MAN_PAGE);
 
     let answer = if parser.args.is_empty() {
         "y".to_owned()


### PR DESCRIPTION
- Added common arg_parser utility for coreutils.
- Every utility has --help and invalid args handler except for `test` and `tr`.
- Fixed basename empty argument error uses stderr instead of stdout.